### PR TITLE
Fix Empty Text/DisplayMemberPaths not working in non-Windows

### DIFF
--- a/src/AutoCompleteEntry/AutoCompleteEntry.cs
+++ b/src/AutoCompleteEntry/AutoCompleteEntry.cs
@@ -22,6 +22,7 @@
         /// <value>
         /// The property path that is used to get the value for display in the text box portion
         /// of the <see cref="AutoCompleteEntry"/> control, when an item is selected.
+        /// The default is an empty string (""), which will use the item's ToString() method.
         /// </value>
         public string TextMemberPath
         {
@@ -40,8 +41,8 @@
         /// Gets or sets the name or path of the property that is displayed for each data item.
         /// </summary>
         /// <value>
-        /// The name or path of the property that is displayed for each the data item in
-        /// the control. The default is an empty string ("").
+        /// The name or path of the property that is displayed for each the data item in the control.
+        /// The default is an empty string (""), which will use the item's ToString() method.
         /// </value>
         public string DisplayMemberPath
         {

--- a/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryExtensions.cs
+++ b/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryExtensions.cs
@@ -40,8 +40,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         public static void UpdateDisplayMemberPath(this AndroidAutoCompleteEntry androidAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
             androidAutoCompleteEntry.SetItems(autoCompleteEntry.ItemsSource,
-                                              (o) => o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath),
-                                              (o) => o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath));
+                                              (o) => !string.IsNullOrEmpty(autoCompleteEntry?.DisplayMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath) : o?.ToString(),
+                                              (o) => !string.IsNullOrEmpty(autoCompleteEntry?.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath) : o?.ToString());
         }
 
         /// <summary>
@@ -72,8 +72,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         public static void UpdateItemsSource(this AndroidAutoCompleteEntry androidAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
             androidAutoCompleteEntry.SetItems(autoCompleteEntry?.ItemsSource, 
-                                              (o) => o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath), 
-                                              (o) => o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath));
+                                              (o) => !string.IsNullOrEmpty(autoCompleteEntry?.DisplayMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath) : o?.ToString(),
+                                              (o) => !string.IsNullOrEmpty(autoCompleteEntry?.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath) : o?.ToString());
         }
 
         /// <summary>
@@ -83,7 +83,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         /// <param name="autoCompleteEntry"></param>
         public static void UpdateSelectedSuggestion(this AndroidAutoCompleteEntry androidAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
-            androidAutoCompleteEntry.Text = autoCompleteEntry.SelectedSuggestion.GetPropertyValueAsString(autoCompleteEntry.TextMemberPath);
+            object o = autoCompleteEntry.SelectedSuggestion;
+            androidAutoCompleteEntry.Text = !string.IsNullOrEmpty(autoCompleteEntry.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry.TextMemberPath) : o?.ToString();
             androidAutoCompleteEntry.SetSelection(androidAutoCompleteEntry.Text?.Length ?? 0);
         }
     }

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryExtensions.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryExtensions.cs
@@ -94,8 +94,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         public static void UpdateDisplayMemberPath(this IOSAutoCompleteEntry iosAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
             iosAutoCompleteEntry.SetItems(autoCompleteEntry.ItemsSource,
-                                          (o) => o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath),
-                                          (o) => o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath));
+                                          (o) => !string.IsNullOrEmpty(autoCompleteEntry?.DisplayMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath) : o?.ToString(),
+                                          (o) => !string.IsNullOrEmpty(autoCompleteEntry?.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath) : o?.ToString());
         }
 
         /// <summary>
@@ -126,8 +126,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         public static void UpdateItemsSource(this IOSAutoCompleteEntry iosAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
             iosAutoCompleteEntry.SetItems(autoCompleteEntry?.ItemsSource,
-                                          (o) => o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath),
-                                          (o) => o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath));
+                                          (o) => !string.IsNullOrEmpty(autoCompleteEntry?.DisplayMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath) : o?.ToString(),
+                                          (o) => !string.IsNullOrEmpty(autoCompleteEntry?.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath) : o?.ToString());
         }
 
         /// <summary>
@@ -137,7 +137,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         /// <param name="autoCompleteEntry"></param>
         public static void UpdateSelectedSuggestion(this IOSAutoCompleteEntry iosAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
-            iosAutoCompleteEntry.Text = autoCompleteEntry.SelectedSuggestion.GetPropertyValueAsString(autoCompleteEntry.TextMemberPath);
+            object o = autoCompleteEntry.SelectedSuggestion;
+            iosAutoCompleteEntry.Text = !string.IsNullOrEmpty(autoCompleteEntry.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry.TextMemberPath) : o?.ToString();
         }
     }
 }

--- a/src/AutoCompleteEntry/Platforms/Windows/AutoCompleteEntryExtensions.cs
+++ b/src/AutoCompleteEntry/Platforms/Windows/AutoCompleteEntryExtensions.cs
@@ -160,7 +160,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         /// <param name="autoCompleteEntry"></param>
         public static void UpdateSelectedSuggestion(this AutoSuggestBox platformControl, AutoCompleteEntry autoCompleteEntry)
         {
-            platformControl.Text = autoCompleteEntry.SelectedSuggestion.GetPropertyValueAsString(autoCompleteEntry.TextMemberPath);
+            object o = autoCompleteEntry.SelectedSuggestion;
+            platformControl.Text = !string.IsNullOrEmpty(autoCompleteEntry.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry.TextMemberPath) : o?.ToString();
         }
 
         private static void UpdateColors(Microsoft.UI.Xaml.ResourceDictionary resource, string[] keys, Microsoft.UI.Xaml.Media.Brush brush)

--- a/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryExtensions.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryExtensions.cs
@@ -94,8 +94,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         public static void UpdateDisplayMemberPath(this IOSAutoCompleteEntry iosAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
             iosAutoCompleteEntry.SetItems(autoCompleteEntry.ItemsSource,
-                                          (o) => o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath),
-                                          (o) => o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath));
+                                          (o) => !string.IsNullOrEmpty(autoCompleteEntry?.DisplayMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath) : o?.ToString(),
+                                          (o) => !string.IsNullOrEmpty(autoCompleteEntry?.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath) : o?.ToString());
         }
 
         /// <summary>
@@ -126,8 +126,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         public static void UpdateItemsSource(this IOSAutoCompleteEntry iosAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
             iosAutoCompleteEntry.SetItems(autoCompleteEntry?.ItemsSource,
-                                          (o) => o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath),
-                                          (o) => o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath));
+                                          (o) => !string.IsNullOrEmpty(autoCompleteEntry?.DisplayMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.DisplayMemberPath) : o?.ToString(),
+                                          (o) => !string.IsNullOrEmpty(autoCompleteEntry?.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry?.TextMemberPath) : o?.ToString());
         }
 
         /// <summary>
@@ -137,7 +137,8 @@ namespace zoft.MauiExtensions.Controls.Platform
         /// <param name="autoCompleteEntry"></param>
         public static void UpdateSelectedSuggestion(this IOSAutoCompleteEntry iosAutoCompleteEntry, AutoCompleteEntry autoCompleteEntry)
         {
-            iosAutoCompleteEntry.Text = autoCompleteEntry.SelectedSuggestion.GetPropertyValueAsString(autoCompleteEntry.TextMemberPath);
+            object o = autoCompleteEntry.SelectedSuggestion;
+            iosAutoCompleteEntry.Text = !string.IsNullOrEmpty(autoCompleteEntry.TextMemberPath) ? o.GetPropertyValueAsString(autoCompleteEntry.TextMemberPath) : o?.ToString();
         }
     }
 }

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -11,10 +11,10 @@
     <PackageProjectUrl>https://github.com/zleao/zoft.MauiExtensions.AutoCompleteEntry</PackageProjectUrl>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>3.0.3</Version>
+    <Version>3.0.4</Version>
     <Description>.Net MAUI Entry control that provides a list of suggestions as the user types.</Description>
     <PackageTags>net8 maui zoft AutoCompleteEntry AutoCompleteBox AutoCompleteView AutoComplete</PackageTags>
-    <PackageReleaseNotes>Fix usage of 'platformView' in Entry Handlers</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix Empty Text/DisplayMemberPaths not working in non-Windows</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Issue:
- The TextMemberPath and DisplayMemberPath properties if unset (string.Empty) end up causing null to be displayed on non-Windows. Instead, not specifying these should use the object's ToString() method.
- It works on Windows because this in Windows the implementation is plumbed to Windows.UI.Xaml.Controls.AutoSuggestBox.TextMemberPath which handles empty strings as the object's ToString(). In non-Windows, the helper extension method GetPropertyValueAsString doesn't handle empty strings as the property name and returns null instead.
- This needs to be consistent across platforms, and supporting empty member paths allows the control to be bound to a direct string collection (where the item itself needs to be displayed rather than a property on the item).

Changes:
1. AutoCompleteEntry:
- Update summary comment indicating that empty/unspecified strings are handled as ToString().

2. AutoCompleteEntryExtensions:
- Handle memberpath to provide ToString() when not specified.