### PR TITLE
Fix Completed event not firing

### DIFF
--- a/sample/AutoCompleteEntry.Sample/ViewModels/SampleViewModel.cs
+++ b/sample/AutoCompleteEntry.Sample/ViewModels/SampleViewModel.cs
@@ -1,5 +1,4 @@
-﻿using AndroidX.AppCompat.View.Menu;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.ObjectModel;
 using zoft.MauiExtensions.Core.Extensions;
 using zoft.MauiExtensions.Core.ViewModels;
@@ -78,6 +77,11 @@ namespace AutoCompleteEntry.Sample.ViewModels
             FilteredList = new ObservableCollection<ListItem>(
                 Teams.Where(t => t.Group.Contains(filter, StringComparison.CurrentCultureIgnoreCase) ||
                                  t.Country.Contains(filter, StringComparison.CurrentCultureIgnoreCase)));
+        }
+
+        public ListItem GetExactMatch(string text)
+        {
+            return Teams.FirstOrDefault(t => t.Country.Equals(text, StringComparison.CurrentCultureIgnoreCase));
         }
 
         private void OnTextChanged(string text)

--- a/sample/AutoCompleteEntry.Sample/Views/WithBindingsPage.xaml
+++ b/sample/AutoCompleteEntry.Sample/Views/WithBindingsPage.xaml
@@ -20,7 +20,8 @@
                                     TextMemberPath="Country"
                                     DisplayMemberPath="Country"
                                     TextChangedCommand="{Binding TextChangedCommand}"
-                                    SelectedSuggestion="{Binding SelectedItem}"/>
+                                    SelectedSuggestion="{Binding SelectedItem}"
+                                    Completed="AutoCompleteEntry_Completed"/>
 
             <Frame BorderColor="Gray" 
                    BackgroundColor="LightGray" 

--- a/sample/AutoCompleteEntry.Sample/Views/WithBindingsPage.xaml.cs
+++ b/sample/AutoCompleteEntry.Sample/Views/WithBindingsPage.xaml.cs
@@ -10,5 +10,14 @@ namespace AutoCompleteEntry.Sample.Views
 
             InitializeComponent();
         }
+
+        private void AutoCompleteEntry_Completed(object sender, EventArgs e)
+        {
+            if (sender is zoft.MauiExtensions.Controls.AutoCompleteEntry autoCompleteEntry &&
+                BindingContext is SampleViewModel viewModel)
+            {
+                viewModel.SelectedItem = viewModel.GetExactMatch(autoCompleteEntry.Text);
+            }
+        }
     }
 }

--- a/sample/AutoCompleteEntry.Sample/Views/WithEventsPage.xaml
+++ b/sample/AutoCompleteEntry.Sample/Views/WithEventsPage.xaml
@@ -21,6 +21,7 @@
                                     DisplayMemberPath="Country"
                                     TextChanged="AutoCompleteEntry_TextChanged"
                                     SuggestionChosen="AutoCompleteEntry_SuggestionChosen"
+                                    Completed="AutoCompleteEntry_Completed"
                                     HeightRequest="50"/>
         
             <Frame BorderColor="Gray" 

--- a/sample/AutoCompleteEntry.Sample/Views/WithEventsPage.xaml.cs
+++ b/sample/AutoCompleteEntry.Sample/Views/WithEventsPage.xaml.cs
@@ -30,5 +30,13 @@ namespace AutoCompleteEntry.Sample.Views
             // Set sender.Text. You can use args.SelectedItem to build your text string.
             ViewModel.SelectedItem = e.SelectedItem as ListItem;
         }
+
+        private void AutoCompleteEntry_Completed(object sender, EventArgs e)
+        {
+            if (sender is zoft.MauiExtensions.Controls.AutoCompleteEntry autoCompleteEntry)
+            {
+                ViewModel.SelectedItem = ViewModel.GetExactMatch(autoCompleteEntry.Text);
+            }
+        }
     }
 }

--- a/src/AutoCompleteEntry/Platforms/Android/AndroidAutoCompleteEntry.cs
+++ b/src/AutoCompleteEntry/Platforms/Android/AndroidAutoCompleteEntry.cs
@@ -171,8 +171,8 @@ namespace zoft.MauiExtensions.Controls.Platform
                 DismissDropDown();
                 DismissKeyboard();
             }
-            else
-                base.OnEditorAction(actionCode);
+
+            base.OnEditorAction(actionCode);
         }
 
         /// <inheritdoc />

--- a/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryHandler.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Maui.Controls.Platform;
+﻿using Android.Views.InputMethods;
+using Android.Views;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using zoft.MauiExtensions.Controls.Platform;
@@ -18,6 +20,7 @@ namespace zoft.MauiExtensions.Controls.Handlers
             platformView.ViewAttachedToWindow += OnLoaded;
             platformView.TextChanged += AutoCompleteEntry_TextChanged;
             platformView.SuggestionChosen += AutoCompleteEntry_SuggestionChosen;
+            platformView.EditorAction += OnEditorAction;
         }
 
         /// <inheritdoc/>
@@ -26,6 +29,7 @@ namespace zoft.MauiExtensions.Controls.Handlers
             platformView.ViewAttachedToWindow -= OnLoaded;
             platformView.TextChanged -= AutoCompleteEntry_TextChanged;
             platformView.SuggestionChosen -= AutoCompleteEntry_SuggestionChosen;
+            platformView.EditorAction -= OnEditorAction;
 
             base.DisconnectHandler(platformView);
         }
@@ -56,6 +60,47 @@ namespace zoft.MauiExtensions.Controls.Handlers
                 PlatformView?.UpdateIsSuggestionListOpen(VirtualView);
                 PlatformView?.UpdateItemsSource(VirtualView);
             }
+        }
+
+        // Note: this is copied from MAUI's EntryHandler.Android.cs > OnEditorAction
+        private void OnEditorAction(object sender, Android.Widget.TextView.EditorActionEventArgs e)
+        {
+            var returnType = VirtualView?.ReturnType;
+
+            // Inside of the android implementations that map events to listeners, the default return value for "Handled" is always true
+            // This means, just by subscribing to EditorAction/KeyPressed/etc.. you change the behavior of the control
+            // So, we are setting handled to false here in order to maintain default behavior
+            bool handled = false;
+            if (returnType != null)
+            {
+                var actionId = e.ActionId;
+                var evt = e.Event;
+                ImeAction currentInputImeFlag = PlatformView.ImeOptions;
+
+                // On API 34 it looks like they fixed the issue where the actionId is ImeAction.ImeNull when using a keyboard
+                // so I'm just setting the actionId here to the current ImeOptions so the logic can all be simplified
+                if (actionId == ImeAction.ImeNull && evt?.KeyCode == Keycode.Enter)
+                {
+                    actionId = currentInputImeFlag;
+                }
+
+                // keyboard path
+                if (evt?.KeyCode == Keycode.Enter && evt?.Action == KeyEventActions.Down)
+                {
+                    handled = true;
+                }
+                else if (evt?.KeyCode == Keycode.Enter && evt?.Action == KeyEventActions.Up)
+                {
+                    VirtualView?.SendCompleted();
+                }
+                // InputPaneView Path
+                else if (evt?.KeyCode is null && (actionId == ImeAction.Done || actionId == currentInputImeFlag))
+                {
+                    VirtualView?.SendCompleted();
+                }
+            }
+
+            e.Handled = handled;
         }
 
         /// <summary>

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryHandler.cs
@@ -32,6 +32,7 @@ namespace zoft.MauiExtensions.Controls.Handlers
             platformView.SuggestionChosen += AutoCompleteEntry_SuggestionChosen;
             platformView.EditingDidBegin += AutoCompleteEntry_EditingDidBegin;
             platformView.EditingDidEnd += AutoCompleteEntry_EditingDidEnd;
+            platformView.ShouldReturn += AutoCompleteEntry_ShouldReturn;
         }
 
         /// <inheritdoc/>
@@ -42,6 +43,7 @@ namespace zoft.MauiExtensions.Controls.Handlers
             platformView.SuggestionChosen -= AutoCompleteEntry_SuggestionChosen;
             platformView.EditingDidBegin -= AutoCompleteEntry_EditingDidBegin;
             platformView.EditingDidEnd -= AutoCompleteEntry_EditingDidEnd;
+            platformView.ShouldReturn -= AutoCompleteEntry_ShouldReturn;
 
             base.DisconnectHandler(platformView);
         }
@@ -90,12 +92,17 @@ namespace zoft.MauiExtensions.Controls.Handlers
             }
         }
 
-        /// <summary>
-		/// Map the background value
-		/// </summary>
-		/// <param name="handler"></param>
-		/// <param name="entry"></param>
-        public static void MapBackground(IAutoCompleteEntryHandler handler, IEntry entry)
+        private void AutoCompleteEntry_ShouldReturn(object sender, EventArgs e)
+        {
+            VirtualView?.SendCompleted();
+        }
+
+    /// <summary>
+    /// Map the background value
+    /// </summary>
+    /// <param name="handler"></param>
+    /// <param name="entry"></param>
+    public static void MapBackground(IAutoCompleteEntryHandler handler, IEntry entry)
         {
             handler.PlatformView?.InputTextField.UpdateBackground(entry);
         }

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/IOSAutoCompleteEntry.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/IOSAutoCompleteEntry.cs
@@ -30,6 +30,8 @@ namespace zoft.MauiExtensions.Controls.Platform
 
         internal EventHandler EditingDidEnd;
 
+        internal EventHandler ShouldReturn;
+
         private NFloat keyboardHeight;
         private NSLayoutConstraint bottomConstraint;
         private Func<object, string> textFunc;
@@ -114,6 +116,7 @@ namespace zoft.MauiExtensions.Controls.Platform
             InputTextField.EditingDidBegin += InputText_OnEditingDidBegin;
             InputTextField.EditingDidEnd += InputText_OnEditingDidEnd;
             InputTextField.EditingChanged += InputText_OnEditingChanged;
+            InputTextField.ShouldReturn += InputText_OnShouldReturn;
 
             AddSubview(InputTextField);
 
@@ -188,8 +191,14 @@ namespace zoft.MauiExtensions.Controls.Platform
             IsSuggestionListOpen = true;
         }
 
-        /// <inheritdoc />
-        public override void LayoutSubviews()
+        private bool InputText_OnShouldReturn(UITextField view)
+        {
+            ShouldReturn?.Invoke(this, EventArgs.Empty);
+            return false;
+        }
+
+    /// <inheritdoc />
+    public override void LayoutSubviews()
         {
             base.LayoutSubviews();
             AddBottomBorder();

--- a/src/AutoCompleteEntry/Platforms/Windows/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Platforms/Windows/AutoCompleteEntryHandler.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
 using zoft.MauiExtensions.Controls.Platform;
 
 namespace zoft.MauiExtensions.Controls.Handlers
@@ -21,7 +23,7 @@ namespace zoft.MauiExtensions.Controls.Handlers
             platformView.TextChanged += AutoSuggestBox_TextChanged;
             platformView.SuggestionChosen += AutoSuggestBox_SuggestionChosen;
             platformView.GotFocus += Control_GotFocus;
-
+            platformView.KeyUp += OnPlatformKeyUp;
         }
 
         /// <inheritdoc/>
@@ -31,6 +33,7 @@ namespace zoft.MauiExtensions.Controls.Handlers
             platformView.TextChanged -= AutoSuggestBox_TextChanged;
             platformView.SuggestionChosen -= AutoSuggestBox_SuggestionChosen;
             platformView.GotFocus -= Control_GotFocus;
+            platformView.KeyUp -= OnPlatformKeyUp;
 
             base.DisconnectHandler(platformView);
         }
@@ -70,6 +73,20 @@ namespace zoft.MauiExtensions.Controls.Handlers
             {
                 PlatformView.IsSuggestionListOpen = true;
             }
+        }
+
+        // Note: this is copied from MAUI's EntryHandler.Windows.cs > OnPlatformKeyUp
+        void OnPlatformKeyUp(object sender, KeyRoutedEventArgs args)
+        {
+            if (args?.Key != VirtualKey.Enter)
+                return;
+
+            if (VirtualView?.ReturnType == ReturnType.Next)
+            {
+                PlatformView?.TryMoveFocus(FocusNavigationDirection.Next);
+            }
+
+            VirtualView?.SendCompleted();
         }
 
         /// <summary>

--- a/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Controls.Platform;
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using zoft.MauiExtensions.Controls.Platform;
@@ -32,6 +33,7 @@ namespace zoft.MauiExtensions.Controls.Handlers
             platformView.SuggestionChosen += AutoCompleteEntry_SuggestionChosen;
             platformView.EditingDidBegin += AutoCompleteEntry_EditingDidBegin;
             platformView.EditingDidEnd += AutoCompleteEntry_EditingDidEnd;
+            platformView.ShouldReturn += AutoCompleteEntry_ShouldReturn;
         }
 
         /// <inheritdoc/>
@@ -42,6 +44,7 @@ namespace zoft.MauiExtensions.Controls.Handlers
             platformView.SuggestionChosen -= AutoCompleteEntry_SuggestionChosen;
             platformView.EditingDidBegin -= AutoCompleteEntry_EditingDidBegin;
             platformView.EditingDidEnd -= AutoCompleteEntry_EditingDidEnd;
+            platformView.ShouldReturn -= AutoCompleteEntry_ShouldReturn;
 
             base.DisconnectHandler(platformView);
         }
@@ -88,6 +91,11 @@ namespace zoft.MauiExtensions.Controls.Handlers
             {
                 VirtualView.Unfocus();
             }
+        }
+
+        private void AutoCompleteEntry_ShouldReturn(object sender, EventArgs e)
+        {
+            VirtualView?.SendCompleted();
         }
 
         /// <summary>

--- a/src/AutoCompleteEntry/Platforms/iOS/IOSAutoCompleteEntry.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/IOSAutoCompleteEntry.cs
@@ -30,6 +30,8 @@ namespace zoft.MauiExtensions.Controls.Platform
 
         internal EventHandler EditingDidEnd;
 
+        internal EventHandler ShouldReturn;
+
         private NFloat keyboardHeight;
         private NSLayoutConstraint bottomConstraint;
         private Func<object, string> textFunc;
@@ -114,6 +116,7 @@ namespace zoft.MauiExtensions.Controls.Platform
             InputTextField.EditingDidBegin += InputText_OnEditingDidBegin;
             InputTextField.EditingDidEnd += InputText_OnEditingDidEnd;
             InputTextField.EditingChanged += InputText_OnEditingChanged;
+            InputTextField.ShouldReturn += InputText_OnShouldReturn;
 
             AddSubview(InputTextField);
 
@@ -186,6 +189,12 @@ namespace zoft.MauiExtensions.Controls.Platform
         {
             TextChanged?.Invoke(this, new AutoCompleteEntryTextChangedEventArgs(AutoCompleteEntryTextChangeReason.UserInput));
             IsSuggestionListOpen = true;
+        }
+
+        private bool InputText_OnShouldReturn(UITextField view)
+        {
+            ShouldReturn?.Invoke(this, EventArgs.Empty);
+            return false;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Issue:
- Since AutoCompleteEntry derives from Entry, it should fire the Completed event when user pressed check mark button on on-screen keyboard (Android), Enter (Windows), etc

Changes:
1. Android:
- Plumb EditorAction to Handler, and call OnEditorAction same as MAUI's Entry handler to ensure Completed is fired.

2. Windows:
- Handle same as Entry on Windows.

3. iOS/MacCatalyst:
- Plumb ShouldReturn same as Entry on iOS, invoke SendCompleted.

4. Sample:
- Ensure we receive Completed events and use that to "select" an item that matches exactly.