### PR TITLE
Map return type.

### DIFF
--- a/src/AutoCompleteEntry/Handlers/AutoCompleteEntryHandler.Standard.cs
+++ b/src/AutoCompleteEntry/Handlers/AutoCompleteEntryHandler.Standard.cs
@@ -116,6 +116,13 @@ public partial class AutoCompleteEntryHandler : ViewHandler<AutoCompleteEntry, o
     public static void MapPlaceholderColor(IAutoCompleteEntryHandler handler, IEntry entry) { }
 
     /// <summary>
+    /// Map the ReturnType value
+    /// </summary>
+    /// <param name="handler"></param>
+    /// <param name="entry"></param>
+    public static void MapReturnType(IAutoCompleteEntryHandler handler, IEntry entry) { }
+
+    /// <summary>
     /// Map the SelectedSuggestion value
     /// </summary>
     /// <param name="handler"></param>

--- a/src/AutoCompleteEntry/Handlers/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Handlers/AutoCompleteEntryHandler.cs
@@ -40,6 +40,7 @@ public partial class AutoCompleteEntryHandler : IAutoCompleteEntryHandler
             [nameof(IEntry.MaxLength)] = MapMaxLength,
 			[nameof(IEntry.Placeholder)] = MapPlaceholder,
 			[nameof(IEntry.PlaceholderColor)] = MapPlaceholderColor,
+            [nameof(IEntry.ReturnType)] = MapReturnType,
             [nameof(AutoCompleteEntry.SelectedSuggestion)] = MapSelectedSuggestion,
             [nameof(IEntry.Text)] = MapText,
 			[nameof(IEntry.TextColor)] = MapTextColor,

--- a/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryHandler.cs
@@ -212,6 +212,16 @@ public partial class AutoCompleteEntryHandler : ViewHandler<AutoCompleteEntry, A
     }
 
     /// <summary>
+    /// Map the ReturnType value
+    /// </summary>
+    /// <param name="handler"></param>
+    /// <param name="entry"></param>
+    public static void MapReturnType(IAutoCompleteEntryHandler handler, IEntry entry)
+    {
+        handler.PlatformView?.UpdateReturnType(entry);
+    }
+
+    /// <summary>
     /// Map the HorizontalTextAlignment value
     /// </summary>
     /// <param name="handler"></param>

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryExtensions.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryExtensions.cs
@@ -104,6 +104,16 @@ public static class AutoCompleteEntryExtensions
     }
 
     /// <summary>
+    /// Update the ReturnType
+    /// </summary>
+    /// <param name="iosAutoCompleteEntry"></param>
+    /// <param name="entry"></param>
+    public static void UpdateReturnType(this IOSAutoCompleteEntry iosAutoCompleteEntry, IEntry entry)
+    {
+        iosAutoCompleteEntry.InputTextField.UpdateReturnType(entry);
+    }
+
+    /// <summary>
     /// Update the SelectedSuggestion
     /// </summary>
     /// <param name="iosAutoCompleteEntry"></param>

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryHandler.cs
@@ -258,6 +258,16 @@ public partial class AutoCompleteEntryHandler : ViewHandler<AutoCompleteEntry, I
     }
 
     /// <summary>
+    /// Map the ReturnType value
+    /// </summary>
+    /// <param name="handler"></param>
+    /// <param name="entry"></param>
+    public static void MapReturnType(IAutoCompleteEntryHandler handler, IEntry entry)
+    {
+        handler.PlatformView?.UpdateReturnType(entry);
+    }
+
+    /// <summary>
     /// Map the SelectedSuggestion value
     /// </summary>
     /// <param name="handler"></param>

--- a/src/AutoCompleteEntry/Platforms/Windows/AutoCompleteEntryExtensions.cs
+++ b/src/AutoCompleteEntry/Platforms/Windows/AutoCompleteEntryExtensions.cs
@@ -120,6 +120,16 @@ public static class AutoCompleteEntryExtensions
     }
 
     /// <summary>
+    /// Update the ReturnType
+    /// </summary>
+    /// <param name="platformControl"></param>
+    /// <param name="entry"></param>
+    public static void UpdateReturnType(this AutoSuggestBox platformControl, IEntry entry)
+    {
+        platformControl.FindFirstDescendant<TextBox>()?.UpdateReturnType(entry);
+    }
+
+    /// <summary>
     /// Update the SelectedSuggestion
     /// </summary>
     /// <param name="platformControl"></param>

--- a/src/AutoCompleteEntry/Platforms/Windows/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Platforms/Windows/AutoCompleteEntryHandler.cs
@@ -250,6 +250,16 @@ public partial class AutoCompleteEntryHandler : ViewHandler<AutoCompleteEntry, A
     }
 
     /// <summary>
+    /// Map the ReturnType value
+    /// </summary>
+    /// <param name="handler"></param>
+    /// <param name="entry"></param>
+    public static void MapReturnType(IAutoCompleteEntryHandler handler, IEntry entry)
+    {
+        handler.PlatformView?.UpdateReturnType(entry);
+    }
+
+    /// <summary>
     /// Map the SelectedSuggestion value
     /// </summary>
     /// <param name="handler"></param>

--- a/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryExtensions.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryExtensions.cs
@@ -104,6 +104,16 @@ public static class AutoCompleteEntryExtensions
     }
 
     /// <summary>
+    /// Update the ReturnType
+    /// </summary>
+    /// <param name="iosAutoCompleteEntry"></param>
+    /// <param name="entry"></param>
+    public static void UpdateReturnType(this IOSAutoCompleteEntry iosAutoCompleteEntry, IEntry entry)
+    {
+        iosAutoCompleteEntry.InputTextField.UpdateReturnType(entry);
+    }
+
+    /// <summary>
     /// Update the SelectedSuggestion
     /// </summary>
     /// <param name="iosAutoCompleteEntry"></param>

--- a/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryHandler.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryHandler.cs
@@ -258,6 +258,16 @@ public partial class AutoCompleteEntryHandler : ViewHandler<AutoCompleteEntry, I
     }
 
     /// <summary>
+    /// Map the ReturnType value
+    /// </summary>
+    /// <param name="handler"></param>
+    /// <param name="entry"></param>
+    public static void MapReturnType(IAutoCompleteEntryHandler handler, IEntry entry)
+    {
+        handler.PlatformView?.UpdateReturnType(entry);
+    }
+
+    /// <summary>
     /// Map the SelectedSuggestion value
     /// </summary>
     /// <param name="handler"></param>


### PR DESCRIPTION
Issue:
- If there is more than 1 entry control in the view, AutoCompleteEntry would use a "Next" return type on the Keyboard and this wasn't mapped and thus not overridable.
- The "Done" return type (check mark in Android keyboard) is required to invoke Completed events, so map ReturnType so that it respects setting it on the control.

Changes:
1. AutoCompleteEntryHandler:
- Map IEntry.ReturnType.

2. Android:
- No custom code required by default.

3. ios/MacCatalyst:
- Set it on the InputTextField.

4. Windows:
- Set it on the associated TextBox.