### PR TITLE
Add unit tests and improve iOS cell sizing for suggestions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Unit Tests
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  checks: write  # required by dorny/test-reporter to post results
+
+jobs:
+  unit-tests:
+    name: Unit Tests (.NET 9)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Install .NET MAUI Workload
+        run: dotnet workload restore src/AutoCompleteEntry/AutoCompleteEntry.csproj
+
+      - name: Restore
+        run: dotnet restore src/Tests/AutoCompleteEntry.Tests/AutoCompleteEntry.Tests.csproj
+
+      - name: Build & Test
+        run: >
+          dotnet test src/Tests/AutoCompleteEntry.Tests/AutoCompleteEntry.Tests.csproj
+          --no-restore
+          --configuration Release
+          --logger "trx;LogFileName=results.trx"
+          --results-directory TestResults
+
+      - name: Publish Test Results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Unit Tests (.NET 9)
+          path: TestResults/results.trx
+          reporter: dotnet-trx

--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,5 @@ MigrationBackup/
 src/.idea/
 src/.DS_Store
 .DS_Store
+
+.vshistory/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,9 @@
 variables:
-  
+
   DotNetVersion: '9.0.300'
   PathToProjectFolder: 'src\AutoCompleteEntry'
   PathToProjectFile: '$(PathToProjectFolder)\AutoCompleteEntry.csproj'
+  PathToTestProjectFile: 'src\Tests\AutoCompleteEntry.Tests\AutoCompleteEntry.Tests.csproj'
   BuildConfiguration: Release
 
 # Disable generic automatic trigger for now. To publish a new nuget manage, a manual build must be triggered
@@ -53,12 +54,39 @@ jobs:
           ArtifactName: 'drop'
           publishLocation: 'Container'
 
+  - job: run_unit_tests
+    displayName: Run Unit Tests
+    pool:
+      vmImage: windows-latest
+    steps:
+
+      - task: UseDotNet@2
+        displayName: Install .NET $(DotNetVersion)
+        inputs:
+          packageType: 'sdk'
+          version: '$(DotNetVersion)'
+
+      - task: CmdLine@2
+        displayName: 'Install .NET MAUI Workload'
+        inputs:
+          script: dotnet workload restore $(PathToProjectFile)
+
+      - task: DotNetCoreCLI@2
+        displayName: 'Run Unit Tests'
+        inputs:
+          command: test
+          projects: '$(PathToTestProjectFile)'
+          arguments: '--configuration $(BuildConfiguration)'
+          publishTestResults: true
+
   - job: 'publish_nuget_package'
     displayName: 'Publish NuGet Package'
     pool:
       vmImage: windows-latest
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    dependsOn: build_library
+    dependsOn:
+      - build_library
+      - run_unit_tests
     steps:
 
       - task: DownloadBuildArtifacts@0

--- a/src/AutoCompleteEntry.sln
+++ b/src/AutoCompleteEntry.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.4.33103.184
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11626.88 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoCompleteEntry", "AutoCompleteEntry\AutoCompleteEntry.csproj", "{8B6AB4EC-A828-4831-91D7-21491CC2A2B7}"
 EndProject
@@ -14,6 +14,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sample", "Sample", "{994A39DE-0C69-48B0-885F-1967D8CA4EC5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoCompleteEntry.Sample", "..\sample\AutoCompleteEntry.Sample\AutoCompleteEntry.Sample.csproj", "{EB1F0CEB-7461-4321-AB19-DCE825B0D19A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{1FD0F6FB-436B-4655-BB1E-D4A2BDEB2A66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoCompleteEntry.Tests", "Tests\AutoCompleteEntry.Tests\AutoCompleteEntry.Tests.csproj", "{A7D36355-ECDF-F32D-90BA-62FEADDA9016}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,12 +33,17 @@ Global
 		{EB1F0CEB-7461-4321-AB19-DCE825B0D19A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB1F0CEB-7461-4321-AB19-DCE825B0D19A}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{EB1F0CEB-7461-4321-AB19-DCE825B0D19A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7D36355-ECDF-F32D-90BA-62FEADDA9016}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7D36355-ECDF-F32D-90BA-62FEADDA9016}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7D36355-ECDF-F32D-90BA-62FEADDA9016}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7D36355-ECDF-F32D-90BA-62FEADDA9016}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EB1F0CEB-7461-4321-AB19-DCE825B0D19A} = {994A39DE-0C69-48B0-885F-1967D8CA4EC5}
+		{A7D36355-ECDF-F32D-90BA-62FEADDA9016} = {1FD0F6FB-436B-4655-BB1E-D4A2BDEB2A66}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AC048AEF-1BA3-4DD2-BE83-0B5F5F1F1DC8}

--- a/src/AutoCompleteEntry/AutoCompleteEntry.cs
+++ b/src/AutoCompleteEntry/AutoCompleteEntry.cs
@@ -16,7 +16,7 @@ public class AutoCompleteEntry : Entry
     public AutoCompleteEntry()
     {
     }
-    
+
     /// <summary>
     /// Gets or sets the property path that is used to get the value for display in the
     /// text box portion of the <see cref="AutoCompleteEntry"/> control, when an item is selected.
@@ -179,7 +179,7 @@ public class AutoCompleteEntry : Entry
     public void OnCursorPositionChanged(int cursorPosition)
     {
         if (CursorPosition == cursorPosition) return;
-            
+
         CursorPosition = cursorPosition;
         CursorPositionChanged?.Invoke(this, new AutoCompleteEntryCursorPositionChangedEventArgs(cursorPosition));
     }

--- a/src/AutoCompleteEntry/AutoCompleteEntry.csproj
+++ b/src/AutoCompleteEntry/AutoCompleteEntry.csproj
@@ -5,6 +5,7 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 		<MauiVersion>9.0.110</MauiVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>

--- a/src/AutoCompleteEntry/Helpers/DensityHelper.cs
+++ b/src/AutoCompleteEntry/Helpers/DensityHelper.cs
@@ -1,0 +1,31 @@
+namespace zoft.MauiExtensions.Controls.Platform;
+
+/// <summary>
+/// Provides conversion helpers between MAUI device-independent pixels (DIPs) and physical pixels.
+/// </summary>
+internal static class DensityHelper
+{
+    /// <summary>
+    /// Converts a pixel-based width to a DIP-based measurement constraint.
+    /// Returns <see cref="double.PositiveInfinity"/> when the pixel width is unavailable (≤ 0),
+    /// allowing MAUI to measure with an unconstrained width.
+    /// </summary>
+    internal static double WidthPixelsToDipConstraint(int parentWidthPx, double density)
+    {
+        return parentWidthPx > 0 && density > 0
+            ? parentWidthPx / density
+            : double.PositiveInfinity;
+    }
+
+    /// <summary>
+    /// Converts a DIP-based measured height to physical pixels, rounding up
+    /// so content is never clipped.
+    /// </summary>
+    internal static int HeightDipToPixels(double heightDip, double density)
+    {
+        if (density <= 0)
+            return 0;
+
+        return (int)System.Math.Ceiling(heightDip * density);
+    }
+}

--- a/src/AutoCompleteEntry/Helpers/TemplateIdMapper.cs
+++ b/src/AutoCompleteEntry/Helpers/TemplateIdMapper.cs
@@ -7,6 +7,12 @@ namespace zoft.MauiExtensions.Controls.Platform;
 internal static class TemplateIdMapper
 {
     /// <summary>
+    /// Maximum number of distinct view types supported when using a <see cref="DataTemplateSelector"/>.
+    /// This value must match the pool count declared in the platform adapter's <c>ViewTypeCount</c>.
+    /// </summary>
+    internal const int MaxViewTypes = 10;
+
+    /// <summary>
     /// Returns the integer view-type ID for the given item.
     /// <para>
     /// For a plain <see cref="DataTemplate"/>, always returns <c>0</c> (single pool).
@@ -14,6 +20,9 @@ internal static class TemplateIdMapper
     /// a stable sequential ID, registering new templates in <paramref name="idMap"/> as encountered.
     /// </para>
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a <see cref="DataTemplateSelector"/> produces more than <see cref="MaxViewTypes"/> distinct templates.
+    /// </exception>
     internal static int GetViewType(
         DataTemplate template,
         object item,
@@ -24,10 +33,20 @@ internal static class TemplateIdMapper
         {
             var resolved = selector.SelectTemplate(item, container);
 
-            if (!idMap.ContainsKey(resolved))
-                idMap[resolved] = idMap.Count;
+            if (!idMap.TryGetValue(resolved, out int value))
+            {
+                if (idMap.Count >= MaxViewTypes)
+                {
+                    throw new InvalidOperationException(
+                        $"DataTemplateSelector returned more than {MaxViewTypes} distinct templates. " +
+                        $"Increase {nameof(TemplateIdMapper)}.{nameof(MaxViewTypes)} to support more.");
+                }
 
-            return idMap[resolved];
+                value = idMap.Count;
+                idMap[resolved] = value;
+            }
+
+            return value;
         }
 
         return 0;

--- a/src/AutoCompleteEntry/Helpers/TemplateIdMapper.cs
+++ b/src/AutoCompleteEntry/Helpers/TemplateIdMapper.cs
@@ -1,0 +1,35 @@
+namespace zoft.MauiExtensions.Controls.Platform;
+
+/// <summary>
+/// Maps <see cref="DataTemplate"/> instances to stable integer IDs for use in
+/// platform adapter view-type pools (e.g. Android <c>BaseAdapter.GetItemViewType</c>).
+/// </summary>
+internal static class TemplateIdMapper
+{
+    /// <summary>
+    /// Returns the integer view-type ID for the given item.
+    /// <para>
+    /// For a plain <see cref="DataTemplate"/>, always returns <c>0</c> (single pool).
+    /// For a <see cref="DataTemplateSelector"/>, resolves the template for the item and assigns
+    /// a stable sequential ID, registering new templates in <paramref name="idMap"/> as encountered.
+    /// </para>
+    /// </summary>
+    internal static int GetViewType(
+        DataTemplate template,
+        object item,
+        BindableObject container,
+        Dictionary<DataTemplate, int> idMap)
+    {
+        if (template is DataTemplateSelector selector)
+        {
+            var resolved = selector.SelectTemplate(item, container);
+
+            if (!idMap.ContainsKey(resolved))
+                idMap[resolved] = idMap.Count;
+
+            return idMap[resolved];
+        }
+
+        return 0;
+    }
+}

--- a/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryAdapter.cs
+++ b/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryAdapter.cs
@@ -1,9 +1,8 @@
-﻿using Android.Content;
+using Android.Content;
 using Android.Views;
 using Android.Widget;
 using Java.Lang;
-using Microsoft.Maui.Controls.Internals;
-using zoft.MauiExtensions.Core.Extensions;
+using Microsoft.Maui.Platform;
 using AView = Android.Views.View;
 
 namespace zoft.MauiExtensions.Controls.Platform;
@@ -14,30 +13,28 @@ internal class AutoCompleteEntryAdapter : BaseAdapter, IFilterable
     private List<object> resultList;
     private string _displayMemberPath;
     private DataTemplate _defaultTemplate;
+    private readonly Dictionary<DataTemplate, int> _templateToIdMap = new();
     Page _listViewContainer;
     private bool _disposed = false;
-        
+
     internal IMauiContext MauiContext => _listViewContainer.Handler.MauiContext;
-        
+
     public DataTemplate ItemTemplate { get; internal set; }
 
     internal DataTemplate DefaultTemplate
     {
         get
         {
-            if (_defaultTemplate == null)
-            {
-                _defaultTemplate = new DataTemplate(() =>
+            _defaultTemplate ??= new DataTemplate(() =>
                 {
                     var label = new Label();
                     label.SetBinding(Label.TextProperty, _displayMemberPath ?? ".");
                     label.HorizontalTextAlignment = Microsoft.Maui.TextAlignment.Center;
                     label.VerticalTextAlignment = Microsoft.Maui.TextAlignment.Center;
-                    label.MinimumHeightRequest = 35;
+                    label.MinimumHeightRequest = 44;
 
                     return label;
                 });
-            }
             return _defaultTemplate;
         }
     }
@@ -47,7 +44,7 @@ internal class AutoCompleteEntryAdapter : BaseAdapter, IFilterable
         _listViewContainer = Application.Current.Windows[0].Page;
 
         resultList = new List<object>();
-        
+
         NotifyDataSetChanged();
     }
 
@@ -91,31 +88,69 @@ internal class AutoCompleteEntryAdapter : BaseAdapter, IFilterable
         return position;
     }
 
+    // Returns the number of distinct recycling pools Android should maintain.
+    // One pool for a plain DataTemplate; up to 10 for a DataTemplateSelector.
+    public override int ViewTypeCount
+        => ItemTemplate is DataTemplateSelector ? 10 : 1;
+
+    // Maps each resolved DataTemplate to a stable integer pool ID so Android
+    // never hands GetView a recycled view of the wrong template type.
+    public override int GetItemViewType(int position)
+    {
+        var item = GetObject(position);
+        var template = ItemTemplate ?? DefaultTemplate;
+        return TemplateIdMapper.GetViewType(template, item, _listViewContainer, _templateToIdMap);
+    }
+
     public override AView GetView(int position, AView convertView, ViewGroup parent)
     {
         var item = GetObject(position);
+        var template = ItemTemplate ?? DefaultTemplate;
 
-        Microsoft.Maui.Controls.Platform.Compatibility.ContainerView result = null;
-        if (convertView != null)
+        // Resolve DataTemplateSelector if needed
+        var resolvedTemplate = template is DataTemplateSelector selector
+            ? selector.SelectTemplate(item, _listViewContainer)
+            : template;
+
+        Microsoft.Maui.Controls.View templateView;
+        AView nativeView;
+
+        // Recycle if possible — only update the binding context, skip handler + native view creation
+        if (convertView != null && convertView.Tag is ViewWrapperTag tag)
         {
-            result = convertView as Microsoft.Maui.Controls.Platform.Compatibility.ContainerView;
-            result.View.BindingContext = item;
+            nativeView = convertView;
+            templateView = tag.MauiView;
+            templateView.BindingContext = item;
         }
         else
         {
-            var template = ItemTemplate ?? DefaultTemplate;
-            var view = (Microsoft.Maui.Controls.View)template.CreateContent(item, _listViewContainer);
-            view.BindingContext = item;
+            // First few visible rows: create MAUI view + native handler from scratch
+            templateView = (Microsoft.Maui.Controls.View)resolvedTemplate.CreateContent();
+            templateView.BindingContext = item;
 
-            result = new Microsoft.Maui.Controls.Platform.Compatibility.ContainerView(parent.Context, view, MauiContext);
-            result.MatchWidth = true;
+            nativeView = templateView.ToPlatform(MauiContext);
 
-            //TODO is internal - find better solution to set true value.
-            //result.MeasureHeight = true;
-            result.SetPropertyValue("MeasureHeight", true);
+            // Stash the MAUI view in the native view's Tag so it can be retrieved on recycle
+            nativeView.Tag = new ViewWrapperTag { MauiView = templateView };
         }
 
-        return result;
+        // Measure after handler creation so MAUI's layout system can resolve sizes.
+        // Re-measure on every GetView call because recycled rows may bind to data of a different height.
+        var density = (double)parent.Context.Resources.DisplayMetrics.Density;
+        var widthConstraint = DensityHelper.WidthPixelsToDipConstraint(parent.Width, density);
+        var measure = ((IView)templateView).Measure(widthConstraint, double.PositiveInfinity);
+
+        var heightPx = DensityHelper.HeightDipToPixels(measure.Height, density);
+        nativeView.LayoutParameters = new ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MatchParent,
+            heightPx);
+
+        return nativeView;
+    }
+
+    internal sealed class ViewWrapperTag : Java.Lang.Object
+    {
+        internal Microsoft.Maui.Controls.View MauiView { get; set; }
     }
 
     private class CustomFilter : Filter

--- a/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryAdapter.cs
+++ b/src/AutoCompleteEntry/Platforms/Android/AutoCompleteEntryAdapter.cs
@@ -19,7 +19,21 @@ internal class AutoCompleteEntryAdapter : BaseAdapter, IFilterable
 
     internal IMauiContext MauiContext => _listViewContainer.Handler.MauiContext;
 
-    public DataTemplate ItemTemplate { get; internal set; }
+    private DataTemplate _itemTemplate;
+    public DataTemplate ItemTemplate
+    {
+        get => _itemTemplate;
+        internal set
+        {
+            if (_itemTemplate == value)
+                return;
+
+            _itemTemplate = value;
+            // Clear stale IDs — old template instances are no longer valid keys
+            // and a new selector may produce a completely different set of templates.
+            _templateToIdMap.Clear();
+        }
+    }
 
     internal DataTemplate DefaultTemplate
     {
@@ -89,9 +103,9 @@ internal class AutoCompleteEntryAdapter : BaseAdapter, IFilterable
     }
 
     // Returns the number of distinct recycling pools Android should maintain.
-    // One pool for a plain DataTemplate; up to 10 for a DataTemplateSelector.
+    // One pool for a plain DataTemplate; up to MaxViewTypes for a DataTemplateSelector.
     public override int ViewTypeCount
-        => ItemTemplate is DataTemplateSelector ? 10 : 1;
+        => ItemTemplate is DataTemplateSelector ? TemplateIdMapper.MaxViewTypes : 1;
 
     // Maps each resolved DataTemplate to a stable integer pool ID so Android
     // never hands GetView a recycled view of the wrong template type.
@@ -112,6 +126,10 @@ internal class AutoCompleteEntryAdapter : BaseAdapter, IFilterable
             ? selector.SelectTemplate(item, _listViewContainer)
             : template;
 
+        if (resolvedTemplate is null)
+            throw new InvalidOperationException(
+                $"The item template selector returned null. Template source type: {template.GetType().FullName}.");
+
         Microsoft.Maui.Controls.View templateView;
         AView nativeView;
 
@@ -125,7 +143,14 @@ internal class AutoCompleteEntryAdapter : BaseAdapter, IFilterable
         else
         {
             // First few visible rows: create MAUI view + native handler from scratch
-            templateView = (Microsoft.Maui.Controls.View)resolvedTemplate.CreateContent();
+            var createdContent = resolvedTemplate.CreateContent();
+            if (createdContent is not Microsoft.Maui.Controls.View createdView)
+                throw new InvalidOperationException(
+                    $"The resolved item template '{resolvedTemplate.GetType().FullName}' must create a " +
+                    $"{typeof(Microsoft.Maui.Controls.View).FullName}, but created " +
+                    $"'{createdContent?.GetType().FullName ?? "null"}'.");
+
+            templateView = createdView;
             templateView.BindingContext = item;
 
             nativeView = templateView.ToPlatform(MauiContext);

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryTableSource.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryTableSource.cs
@@ -32,7 +32,7 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
                     label.SetBinding(Label.TextProperty, _displayMemberPath ?? ".");
                     label.HorizontalTextAlignment = Microsoft.Maui.TextAlignment.Center;
                     label.VerticalTextAlignment = Microsoft.Maui.TextAlignment.Center;
-                    label.MinimumHeightRequest = 35;
+                    label.MinimumHeightRequest = 44;
 
                     return label;
                 });
@@ -51,6 +51,9 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         _mauiContext = mauiContext;
         //_cellIdentifier = Guid.NewGuid().ToString();
         _listViewContainer = Application.Current.Windows[0].Page;
+
+        _view.EstimatedRowHeight = 60f;
+        _view.RowHeight = UITableView.AutomaticDimension;
 
         CheckIfItemsSourceIsNotifiable();
     }
@@ -112,10 +115,15 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
             subview.RemoveFromSuperview();
         }
 
-        nativeView.Frame = cell.ContentView.Bounds;
-        nativeView.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
-
+        nativeView.TranslatesAutoresizingMaskIntoConstraints = false;
         cell.ContentView.AddSubview(nativeView);
+        NSLayoutConstraint.ActivateConstraints(new[]
+        {
+            nativeView.LeadingAnchor.ConstraintEqualTo(cell.ContentView.LeadingAnchor),
+            nativeView.TrailingAnchor.ConstraintEqualTo(cell.ContentView.TrailingAnchor),
+            nativeView.TopAnchor.ConstraintEqualTo(cell.ContentView.TopAnchor),
+            nativeView.BottomAnchor.ConstraintEqualTo(cell.ContentView.BottomAnchor)
+        });
 
         return cell;
     }
@@ -128,11 +136,6 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
     public override nint RowsInSection(UITableView tableview, nint section)
     {
         return _items.Count;
-    }
-
-    public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
-    {
-        return 35f;
     }
 
     public event EventHandler<TableRowSelectedEventArgs<object>> TableRowSelected;

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryTableSource.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryTableSource.cs
@@ -60,7 +60,7 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         }
     }
 
-    private void NotifiableItems_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    private void NotifiableItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         if (!MainThread.IsMainThread)
         {
@@ -92,18 +92,19 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         var item = _items[indexPath.Row];
         var templateToUse = _itemTemplate ?? DefaultItemTemplate;
 
-        // cellId is derived from the resolved DataTemplate, so UITableView naturally
-        // maintains a separate recycling pool per template type — DataTemplateSelector works for free.
-        var cellId = ((IDataTemplateController)templateToUse.SelectDataTemplate(item, _listViewContainer)).IdString;
+        // Resolve the concrete DataTemplate (returns self for a plain DataTemplate,
+        // selects one when templateToUse is a DataTemplateSelector).
+        var resolvedTemplate = templateToUse.SelectDataTemplate(item, _listViewContainer);
+        var cellId = ((IDataTemplateController)resolvedTemplate).IdString;
 
-        var cell = tableView.DequeueReusableCell(cellId) as AutoCompleteCell;
-
-        if (cell == null)
+        if (tableView.DequeueReusableCell(cellId) is not AutoCompleteCell cell)
         {
             // First time for this template type — create the MAUI view and its handler
             cell = new AutoCompleteCell(cellId);
 
-            var templateView = templateToUse.CreateContent() as View;
+            var templateView = resolvedTemplate.CreateContent() as View
+                ?? throw new InvalidOperationException(
+                    $"DataTemplate did not produce a View for item '{item}'.");
             templateView.BindingContext = item;
             cell.MauiView = templateView;
 
@@ -130,13 +131,13 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         else
         {
             // Recycled cell — skip handler creation, just swap the data
-            cell.MauiView.BindingContext = item;
+            cell.MauiView!.BindingContext = item;
         }
 
         // Measure on every GetCell call because recycled rows may bind to data of a different height
         var widthConstraint = tableView.Bounds.Width > 0 ? (double)tableView.Bounds.Width : double.PositiveInfinity;
-        var measure = ((IView)cell.MauiView).Measure(widthConstraint, double.PositiveInfinity);
-        cell.HeightConstraint.Constant = (nfloat)measure.Height;
+        var measure = ((IView)cell.MauiView!).Measure(widthConstraint, double.PositiveInfinity);
+        cell.HeightConstraint!.Constant = (nfloat)measure.Height;
 
         return cell;
     }
@@ -166,8 +167,8 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
 /// </summary>
 internal sealed class AutoCompleteCell : UITableViewCell
 {
-    internal View MauiView { get; set; }
-    internal NSLayoutConstraint HeightConstraint { get; set; }
+    internal View? MauiView { get; set; }
+    internal NSLayoutConstraint? HeightConstraint { get; set; }
 
     internal AutoCompleteCell(string cellId) : base(UITableViewCellStyle.Default, cellId) { }
 }

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryTableSource.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/AutoCompleteEntryTableSource.cs
@@ -14,8 +14,6 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
     private readonly string _displayMemberPath;
     private readonly DataTemplate _itemTemplate;
     private readonly IMauiContext _mauiContext;
-
-    //private readonly string _cellIdentifier;
     private readonly Page _listViewContainer;
 
     private DataTemplate _defaultItemTemplate;
@@ -23,9 +21,7 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
     {
         get
         {
-            if (_defaultItemTemplate == null)
-            {
-                _defaultItemTemplate = new DataTemplate(() =>
+            _defaultItemTemplate ??= new DataTemplate(() =>
                 {
                     var label = new Label();
 
@@ -36,7 +32,6 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
 
                     return label;
                 });
-            }
 
             return _defaultItemTemplate;
         }
@@ -49,7 +44,6 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         _displayMemberPath = displayMemberPath;
         _itemTemplate = itemTemplate;
         _mauiContext = mauiContext;
-        //_cellIdentifier = Guid.NewGuid().ToString();
         _listViewContainer = Application.Current.Windows[0].Page;
 
         _view.EstimatedRowHeight = 60f;
@@ -98,32 +92,51 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         var item = _items[indexPath.Row];
         var templateToUse = _itemTemplate ?? DefaultItemTemplate;
 
+        // cellId is derived from the resolved DataTemplate, so UITableView naturally
+        // maintains a separate recycling pool per template type — DataTemplateSelector works for free.
         var cellId = ((IDataTemplateController)templateToUse.SelectDataTemplate(item, _listViewContainer)).IdString;
 
-        var cell = tableView.DequeueReusableCell(cellId) ?? new UITableViewCell(UITableViewCellStyle.Default, cellId);
+        var cell = tableView.DequeueReusableCell(cellId) as AutoCompleteCell;
 
-        // Create the MAUI view from the DataTemplate
-        var templateView = templateToUse.CreateContent() as View;
-        templateView.BindingContext = item;
-
-        // Convert MAUI view to native iOS view with proper MauiContext
-        var nativeView = templateView.ToPlatform(_mauiContext);
-
-        // Clear previous content to avoid overlapping
-        foreach (var subview in cell.ContentView.Subviews)
+        if (cell == null)
         {
-            subview.RemoveFromSuperview();
+            // First time for this template type — create the MAUI view and its handler
+            cell = new AutoCompleteCell(cellId);
+
+            var templateView = templateToUse.CreateContent() as View;
+            templateView.BindingContext = item;
+            cell.MauiView = templateView;
+
+            var nativeView = templateView.ToPlatform(_mauiContext);
+            nativeView.TranslatesAutoresizingMaskIntoConstraints = false;
+            cell.ContentView.AddSubview(nativeView);
+
+            // Pin to all 4 edges — done once per cell, never repeated on recycle
+            NSLayoutConstraint.ActivateConstraints(new[]
+            {
+                nativeView.LeadingAnchor.ConstraintEqualTo(cell.ContentView.LeadingAnchor),
+                nativeView.TrailingAnchor.ConstraintEqualTo(cell.ContentView.TrailingAnchor),
+                nativeView.TopAnchor.ConstraintEqualTo(cell.ContentView.TopAnchor),
+                nativeView.BottomAnchor.ConstraintEqualTo(cell.ContentView.BottomAnchor)
+            });
+
+            // Stash a reusable height constraint at priority 999 so it informs
+            // AutomaticDimension without conflicting with the edge constraints.
+            // We update only its Constant on recycle — no new constraint objects.
+            cell.HeightConstraint = nativeView.HeightAnchor.ConstraintEqualTo(44f);
+            cell.HeightConstraint.Priority = 999;
+            cell.HeightConstraint.Active = true;
+        }
+        else
+        {
+            // Recycled cell — skip handler creation, just swap the data
+            cell.MauiView.BindingContext = item;
         }
 
-        nativeView.TranslatesAutoresizingMaskIntoConstraints = false;
-        cell.ContentView.AddSubview(nativeView);
-        NSLayoutConstraint.ActivateConstraints(new[]
-        {
-            nativeView.LeadingAnchor.ConstraintEqualTo(cell.ContentView.LeadingAnchor),
-            nativeView.TrailingAnchor.ConstraintEqualTo(cell.ContentView.TrailingAnchor),
-            nativeView.TopAnchor.ConstraintEqualTo(cell.ContentView.TopAnchor),
-            nativeView.BottomAnchor.ConstraintEqualTo(cell.ContentView.BottomAnchor)
-        });
+        // Measure on every GetCell call because recycled rows may bind to data of a different height
+        var widthConstraint = tableView.Bounds.Width > 0 ? (double)tableView.Bounds.Width : double.PositiveInfinity;
+        var measure = ((IView)cell.MauiView).Measure(widthConstraint, double.PositiveInfinity);
+        cell.HeightConstraint.Constant = (nfloat)measure.Height;
 
         return cell;
     }
@@ -145,4 +158,16 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         var item = _items[itemIndexPath.Row];
         TableRowSelected?.Invoke(this, new TableRowSelectedEventArgs<object>(item, itemIndexPath));
     }
+}
+
+/// <summary>
+/// Custom cell that holds MAUI view and height constraint references across recycles,
+/// avoiding repeated handler creation and constraint leaks.
+/// </summary>
+internal sealed class AutoCompleteCell : UITableViewCell
+{
+    internal View MauiView { get; set; }
+    internal NSLayoutConstraint HeightConstraint { get; set; }
+
+    internal AutoCompleteCell(string cellId) : base(UITableViewCellStyle.Default, cellId) { }
 }

--- a/src/AutoCompleteEntry/Platforms/MacCatalyst/IOSAutoCompleteEntry.cs
+++ b/src/AutoCompleteEntry/Platforms/MacCatalyst/IOSAutoCompleteEntry.cs
@@ -1,4 +1,3 @@
-using CoreAnimation;
 using CoreGraphics;
 using Foundation;
 using ObjCRuntime;

--- a/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryTableSource.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryTableSource.cs
@@ -14,8 +14,6 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
     private readonly string _displayMemberPath;
     private readonly DataTemplate _itemTemplate;
     private readonly IMauiContext _mauiContext;
-
-    //private readonly string _cellIdentifier;
     private readonly Page _listViewContainer;
 
     private DataTemplate _defaultItemTemplate;
@@ -23,9 +21,7 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
     {
         get
         {
-            if (_defaultItemTemplate == null)
-            {
-                _defaultItemTemplate = new DataTemplate(() =>
+            _defaultItemTemplate ??= new DataTemplate(() =>
                 {
                     var label = new Label();
 
@@ -36,7 +32,6 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
 
                     return label;
                 });
-            }
 
             return _defaultItemTemplate;
         }
@@ -49,7 +44,6 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         _displayMemberPath = displayMemberPath;
         _itemTemplate = itemTemplate;
         _mauiContext = mauiContext;
-        //_cellIdentifier = Guid.NewGuid().ToString();
         _listViewContainer = Application.Current.Windows[0].Page;
 
         _view.EstimatedRowHeight = 60f;
@@ -98,47 +92,51 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         var item = _items[indexPath.Row];
         var templateToUse = _itemTemplate ?? DefaultItemTemplate;
 
+        // cellId is derived from the resolved DataTemplate, so UITableView naturally
+        // maintains a separate recycling pool per template type — DataTemplateSelector works for free.
         var cellId = ((IDataTemplateController)templateToUse.SelectDataTemplate(item, _listViewContainer)).IdString;
 
-        var cell = tableView.DequeueReusableCell(cellId) ?? new UITableViewCell(UITableViewCellStyle.Default, cellId);
+        var cell = tableView.DequeueReusableCell(cellId) as AutoCompleteCell;
 
-        // Create the MAUI view from the DataTemplate
-        var templateView = templateToUse.CreateContent() as View;
-        templateView.BindingContext = item;
-
-        // Convert MAUI view to native iOS view first (creates the handler)
-        var nativeView = templateView.ToPlatform(_mauiContext);
-
-        // Measure AFTER handler creation so MAUI's layout system can resolve sizes.
-        // MAUI views don't expose intrinsic content size to UIKit Auto Layout,
-        // so we measure explicitly and add a height constraint to inform
-        // UITableView.AutomaticDimension of the desired row height.
-        var widthConstraint = tableView.Bounds.Width > 0 ? (double)tableView.Bounds.Width : double.PositiveInfinity;
-        var measure = ((IView)templateView).Measure(widthConstraint, double.PositiveInfinity);
-
-        // Clear previous content to avoid overlapping
-        foreach (var subview in cell.ContentView.Subviews)
+        if (cell == null)
         {
-            subview.RemoveFromSuperview();
+            // First time for this template type — create the MAUI view and its handler
+            cell = new AutoCompleteCell(cellId);
+
+            var templateView = templateToUse.CreateContent() as View;
+            templateView.BindingContext = item;
+            cell.MauiView = templateView;
+
+            var nativeView = templateView.ToPlatform(_mauiContext);
+            nativeView.TranslatesAutoresizingMaskIntoConstraints = false;
+            cell.ContentView.AddSubview(nativeView);
+
+            // Pin to all 4 edges — done once per cell, never repeated on recycle
+            NSLayoutConstraint.ActivateConstraints(
+            [
+                nativeView.LeadingAnchor.ConstraintEqualTo(cell.ContentView.LeadingAnchor),
+                nativeView.TrailingAnchor.ConstraintEqualTo(cell.ContentView.TrailingAnchor),
+                nativeView.TopAnchor.ConstraintEqualTo(cell.ContentView.TopAnchor),
+                nativeView.BottomAnchor.ConstraintEqualTo(cell.ContentView.BottomAnchor)
+            ]);
+
+            // Stash a reusable height constraint at priority 999 so it informs
+            // AutomaticDimension without conflicting with the edge constraints.
+            // We update only its Constant on recycle — no new constraint objects.
+            cell.HeightConstraint = nativeView.HeightAnchor.ConstraintEqualTo(44f);
+            cell.HeightConstraint.Priority = 999;
+            cell.HeightConstraint.Active = true;
+        }
+        else
+        {
+            // Recycled cell — skip handler creation, just swap the data
+            cell.MauiView.BindingContext = item;
         }
 
-        nativeView.TranslatesAutoresizingMaskIntoConstraints = false;
-        cell.ContentView.AddSubview(nativeView);
-
-        // Pin to all 4 edges for auto-sizing cell support
-        NSLayoutConstraint.ActivateConstraints(
-        [
-            nativeView.LeadingAnchor.ConstraintEqualTo(cell.ContentView.LeadingAnchor),
-            nativeView.TrailingAnchor.ConstraintEqualTo(cell.ContentView.TrailingAnchor),
-            nativeView.TopAnchor.ConstraintEqualTo(cell.ContentView.TopAnchor),
-            nativeView.BottomAnchor.ConstraintEqualTo(cell.ContentView.BottomAnchor)
-        ]);
-
-        // Height at priority 999 (below required 1000) so it informs auto-sizing
-        // without conflicting with the top+bottom edge constraints.
-        var heightConstraint = nativeView.HeightAnchor.ConstraintEqualTo((nfloat)measure.Height);
-        heightConstraint.Priority = 999;
-        heightConstraint.Active = true;
+        // Measure on every GetCell call because recycled rows may bind to data of a different height
+        var widthConstraint = tableView.Bounds.Width > 0 ? (double)tableView.Bounds.Width : double.PositiveInfinity;
+        var measure = ((IView)cell.MauiView).Measure(widthConstraint, double.PositiveInfinity);
+        cell.HeightConstraint.Constant = (nfloat)measure.Height;
 
         return cell;
     }
@@ -160,4 +158,16 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         var item = _items[itemIndexPath.Row];
         TableRowSelected?.Invoke(this, new TableRowSelectedEventArgs<object>(item, itemIndexPath));
     }
+}
+
+/// <summary>
+/// Custom cell that holds MAUI view and height constraint references across recycles,
+/// avoiding repeated handler creation and constraint leaks.
+/// </summary>
+internal sealed class AutoCompleteCell : UITableViewCell
+{
+    internal View MauiView { get; set; }
+    internal NSLayoutConstraint HeightConstraint { get; set; }
+
+    internal AutoCompleteCell(string cellId) : base(UITableViewCellStyle.Default, cellId) { }
 }

--- a/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryTableSource.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryTableSource.cs
@@ -32,7 +32,7 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
                     label.SetBinding(Label.TextProperty, _displayMemberPath ?? ".");
                     label.HorizontalTextAlignment = Microsoft.Maui.TextAlignment.Center;
                     label.VerticalTextAlignment = Microsoft.Maui.TextAlignment.Center;
-                    label.MinimumHeightRequest = 35;
+                    label.MinimumHeightRequest = 44;
 
                     return label;
                 });
@@ -51,6 +51,9 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         _mauiContext = mauiContext;
         //_cellIdentifier = Guid.NewGuid().ToString();
         _listViewContainer = Application.Current.Windows[0].Page;
+
+        _view.EstimatedRowHeight = 60f;
+        _view.RowHeight = UITableView.AutomaticDimension;
 
         CheckIfItemsSourceIsNotifiable();
     }
@@ -103,8 +106,15 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         var templateView = templateToUse.CreateContent() as View;
         templateView.BindingContext = item;
 
-        // Convert MAUI view to native iOS view with proper MauiContext
+        // Convert MAUI view to native iOS view first (creates the handler)
         var nativeView = templateView.ToPlatform(_mauiContext);
+
+        // Measure AFTER handler creation so MAUI's layout system can resolve sizes.
+        // MAUI views don't expose intrinsic content size to UIKit Auto Layout,
+        // so we measure explicitly and add a height constraint to inform
+        // UITableView.AutomaticDimension of the desired row height.
+        var widthConstraint = tableView.Bounds.Width > 0 ? (double)tableView.Bounds.Width : double.PositiveInfinity;
+        var measure = ((IView)templateView).Measure(widthConstraint, double.PositiveInfinity);
 
         // Clear previous content to avoid overlapping
         foreach (var subview in cell.ContentView.Subviews)
@@ -112,10 +122,23 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
             subview.RemoveFromSuperview();
         }
 
-        nativeView.Frame = cell.ContentView.Bounds;
-        nativeView.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
-
+        nativeView.TranslatesAutoresizingMaskIntoConstraints = false;
         cell.ContentView.AddSubview(nativeView);
+
+        // Pin to all 4 edges for auto-sizing cell support
+        NSLayoutConstraint.ActivateConstraints(
+        [
+            nativeView.LeadingAnchor.ConstraintEqualTo(cell.ContentView.LeadingAnchor),
+            nativeView.TrailingAnchor.ConstraintEqualTo(cell.ContentView.TrailingAnchor),
+            nativeView.TopAnchor.ConstraintEqualTo(cell.ContentView.TopAnchor),
+            nativeView.BottomAnchor.ConstraintEqualTo(cell.ContentView.BottomAnchor)
+        ]);
+
+        // Height at priority 999 (below required 1000) so it informs auto-sizing
+        // without conflicting with the top+bottom edge constraints.
+        var heightConstraint = nativeView.HeightAnchor.ConstraintEqualTo((nfloat)measure.Height);
+        heightConstraint.Priority = 999;
+        heightConstraint.Active = true;
 
         return cell;
     }
@@ -128,11 +151,6 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
     public override nint RowsInSection(UITableView tableview, nint section)
     {
         return _items.Count;
-    }
-
-    public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
-    {
-        return 35f;
     }
 
     public event EventHandler<TableRowSelectedEventArgs<object>> TableRowSelected;

--- a/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryTableSource.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/AutoCompleteEntryTableSource.cs
@@ -92,18 +92,19 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         var item = _items[indexPath.Row];
         var templateToUse = _itemTemplate ?? DefaultItemTemplate;
 
-        // cellId is derived from the resolved DataTemplate, so UITableView naturally
-        // maintains a separate recycling pool per template type — DataTemplateSelector works for free.
-        var cellId = ((IDataTemplateController)templateToUse.SelectDataTemplate(item, _listViewContainer)).IdString;
+        // Resolve template (returns self for plain DataTemplate, selects for DataTemplateSelector)
+        var resolvedTemplate = templateToUse.SelectDataTemplate(item, _listViewContainer);
 
-        var cell = tableView.DequeueReusableCell(cellId) as AutoCompleteCell;
+        var cellId = ((IDataTemplateController)resolvedTemplate).IdString;
 
-        if (cell == null)
+        if (tableView.DequeueReusableCell(cellId) is not AutoCompleteCell cell)
         {
             // First time for this template type — create the MAUI view and its handler
             cell = new AutoCompleteCell(cellId);
 
-            var templateView = templateToUse.CreateContent() as View;
+            var templateView = resolvedTemplate.CreateContent() as View
+                ?? throw new InvalidOperationException(
+                    $"DataTemplate did not produce a View for item '{item}'.");
             templateView.BindingContext = item;
             cell.MauiView = templateView;
 
@@ -130,13 +131,13 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
         else
         {
             // Recycled cell — skip handler creation, just swap the data
-            cell.MauiView.BindingContext = item;
+            cell.MauiView!.BindingContext = item;
         }
 
         // Measure on every GetCell call because recycled rows may bind to data of a different height
         var widthConstraint = tableView.Bounds.Width > 0 ? (double)tableView.Bounds.Width : double.PositiveInfinity;
-        var measure = ((IView)cell.MauiView).Measure(widthConstraint, double.PositiveInfinity);
-        cell.HeightConstraint.Constant = (nfloat)measure.Height;
+        var measure = ((IView)cell.MauiView!).Measure(widthConstraint, double.PositiveInfinity);
+        cell.HeightConstraint!.Constant = (nfloat)measure.Height;
 
         return cell;
     }
@@ -166,8 +167,8 @@ internal class AutoCompleteEntryTableSource : UITableViewSource
 /// </summary>
 internal sealed class AutoCompleteCell : UITableViewCell
 {
-    internal View MauiView { get; set; }
-    internal NSLayoutConstraint HeightConstraint { get; set; }
+    internal View? MauiView { get; set; }
+    internal NSLayoutConstraint? HeightConstraint { get; set; }
 
     internal AutoCompleteCell(string cellId) : base(UITableViewCellStyle.Default, cellId) { }
 }

--- a/src/AutoCompleteEntry/Platforms/iOS/IOSAutoCompleteEntry.cs
+++ b/src/AutoCompleteEntry/Platforms/iOS/IOSAutoCompleteEntry.cs
@@ -1,4 +1,3 @@
-using CoreAnimation;
 using CoreGraphics;
 using Foundation;
 using ObjCRuntime;

--- a/src/AutoCompleteEntry/Properties/AssemblyInfo.cs
+++ b/src/AutoCompleteEntry/Properties/AssemblyInfo.cs
@@ -1,1 +1,2 @@
 [assembly: XmlnsDefinition("http://zoft.MauiExtensions/Controls", "zoft.MauiExtensions.Controls")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("AutoCompleteEntry.Tests")]

--- a/src/Tests/AutoCompleteEntry.Tests/AutoCompleteEntry.Tests.csproj
+++ b/src/Tests/AutoCompleteEntry.Tests/AutoCompleteEntry.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>AutoCompleteEntry.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\AutoCompleteEntry\AutoCompleteEntry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/AutoCompleteEntry.Tests/AutoCompleteEntryControlTests.cs
+++ b/src/Tests/AutoCompleteEntry.Tests/AutoCompleteEntryControlTests.cs
@@ -1,0 +1,339 @@
+namespace AutoCompleteEntry.Tests;
+
+/// <summary>
+/// Tests for the shared <see cref="zoft.MauiExtensions.Controls.AutoCompleteEntry"/> control behavior.
+/// These validate the core state management, event flow, and property defaults that the
+/// platform-specific implementations depend on.
+///
+/// Platform-specific behavior (e.g., iOS UITableView row sizing) requires
+/// device/emulator-based integration tests and cannot be exercised in a net9.0 unit test.
+/// </summary>
+public class AutoCompleteEntryControlTests
+{
+    private static zoft.MauiExtensions.Controls.AutoCompleteEntry CreateEntry() => new();
+
+    #region Default Property Values
+
+    [Fact]
+    public void IsSuggestionListOpen_DefaultValue_IsFalse()
+    {
+        var entry = CreateEntry();
+
+        Assert.False(entry.IsSuggestionListOpen);
+    }
+
+    [Fact]
+    public void UpdateTextOnSelect_DefaultValue_IsTrue()
+    {
+        var entry = CreateEntry();
+
+        Assert.True(entry.UpdateTextOnSelect);
+    }
+
+    [Fact]
+    public void ShowBottomBorder_DefaultValue_IsTrue()
+    {
+        var entry = CreateEntry();
+
+        Assert.True(entry.ShowBottomBorder);
+    }
+
+    [Fact]
+    public void TextMemberPath_DefaultValue_IsEmpty()
+    {
+        var entry = CreateEntry();
+
+        Assert.Equal(string.Empty, entry.TextMemberPath);
+    }
+
+    [Fact]
+    public void DisplayMemberPath_DefaultValue_IsEmpty()
+    {
+        var entry = CreateEntry();
+
+        Assert.Equal(string.Empty, entry.DisplayMemberPath);
+    }
+
+    [Fact]
+    public void ItemsSource_DefaultValue_IsNull()
+    {
+        var entry = CreateEntry();
+
+        Assert.Null(entry.ItemsSource);
+    }
+
+    [Fact]
+    public void SelectedSuggestion_DefaultValue_IsNull()
+    {
+        var entry = CreateEntry();
+
+        Assert.Null(entry.SelectedSuggestion);
+    }
+
+    [Fact]
+    public void ItemTemplate_DefaultValue_IsNull()
+    {
+        var entry = CreateEntry();
+
+        Assert.Null(entry.ItemTemplate);
+    }
+
+    #endregion
+
+    #region OnTextChanged
+
+    [Fact]
+    public void OnTextChanged_WithUserInput_UpdatesTextProperty()
+    {
+        var entry = CreateEntry();
+
+        entry.OnTextChanged("hello", AutoCompleteEntryTextChangeReason.UserInput);
+
+        Assert.Equal("hello", entry.Text);
+    }
+
+    [Fact]
+    public void OnTextChanged_WithUserInput_FiresTextChangedEventWithCorrectReason()
+    {
+        var entry = CreateEntry();
+        AutoCompleteEntryTextChangedEventArgs? receivedArgs = null;
+        entry.TextChanged += (_, e) => receivedArgs = e;
+
+        entry.OnTextChanged("hello", AutoCompleteEntryTextChangeReason.UserInput);
+
+        Assert.NotNull(receivedArgs);
+        Assert.Equal(AutoCompleteEntryTextChangeReason.UserInput, receivedArgs.Reason);
+    }
+
+    [Fact]
+    public void OnTextChanged_WithProgrammaticChange_FiresTextChangedEventWithCorrectReason()
+    {
+        var entry = CreateEntry();
+        AutoCompleteEntryTextChangedEventArgs? receivedArgs = null;
+        entry.TextChanged += (_, e) => receivedArgs = e;
+
+        entry.OnTextChanged("hello", AutoCompleteEntryTextChangeReason.ProgrammaticChange);
+
+        Assert.NotNull(receivedArgs);
+        Assert.Equal(AutoCompleteEntryTextChangeReason.ProgrammaticChange, receivedArgs.Reason);
+    }
+
+    [Fact]
+    public void OnTextChanged_WithSuggestionChosen_FiresTextChangedEventWithCorrectReason()
+    {
+        var entry = CreateEntry();
+        AutoCompleteEntryTextChangedEventArgs? receivedArgs = null;
+        entry.TextChanged += (_, e) => receivedArgs = e;
+
+        entry.OnTextChanged("hello", AutoCompleteEntryTextChangeReason.SuggestionChosen);
+
+        Assert.NotNull(receivedArgs);
+        Assert.Equal(AutoCompleteEntryTextChangeReason.SuggestionChosen, receivedArgs.Reason);
+    }
+
+    [Fact]
+    public void OnTextChanged_WithUserInput_ExecutesTextChangedCommand()
+    {
+        var entry = CreateEntry();
+        var command = Substitute.For<ICommand>();
+        command.CanExecute(Arg.Any<object?>()).Returns(true);
+        entry.TextChangedCommand = command;
+
+        entry.OnTextChanged("test", AutoCompleteEntryTextChangeReason.UserInput);
+
+        command.Received(1).Execute("test");
+    }
+
+    [Fact]
+    public void OnTextChanged_WithProgrammaticChange_DoesNotExecuteCommand()
+    {
+        var entry = CreateEntry();
+        var command = Substitute.For<ICommand>();
+        command.CanExecute(Arg.Any<object?>()).Returns(true);
+        entry.TextChangedCommand = command;
+
+        entry.OnTextChanged("test", AutoCompleteEntryTextChangeReason.ProgrammaticChange);
+
+        command.DidNotReceive().Execute(Arg.Any<object?>());
+    }
+
+    [Fact]
+    public void OnTextChanged_WithSuggestionChosen_DoesNotExecuteCommand()
+    {
+        var entry = CreateEntry();
+        var command = Substitute.For<ICommand>();
+        command.CanExecute(Arg.Any<object?>()).Returns(true);
+        entry.TextChangedCommand = command;
+
+        entry.OnTextChanged("test", AutoCompleteEntryTextChangeReason.SuggestionChosen);
+
+        command.DidNotReceive().Execute(Arg.Any<object?>());
+    }
+
+    [Fact]
+    public void OnTextChanged_WithUserInput_WhenCommandCannotExecute_DoesNotExecuteCommand()
+    {
+        var entry = CreateEntry();
+        var command = Substitute.For<ICommand>();
+        command.CanExecute(Arg.Any<object?>()).Returns(false);
+        entry.TextChangedCommand = command;
+
+        entry.OnTextChanged("test", AutoCompleteEntryTextChangeReason.UserInput);
+
+        command.DidNotReceive().Execute(Arg.Any<object?>());
+    }
+
+    [Fact]
+    public void OnTextChanged_WithNoCommandSet_DoesNotThrow()
+    {
+        var entry = CreateEntry();
+
+        var exception = Record.Exception(() =>
+            entry.OnTextChanged("test", AutoCompleteEntryTextChangeReason.UserInput));
+
+        Assert.Null(exception);
+    }
+
+    #endregion
+
+    #region OnSuggestionSelected
+
+    [Fact]
+    public void OnSuggestionSelected_SetsSelectedSuggestionProperty()
+    {
+        var entry = CreateEntry();
+        var item = new { Name = "Test Item" };
+
+        entry.OnSuggestionSelected(item);
+
+        Assert.Same(item, entry.SelectedSuggestion);
+    }
+
+    [Fact]
+    public void OnSuggestionSelected_FiresSuggestionChosenEvent()
+    {
+        var entry = CreateEntry();
+        AutoCompleteEntrySuggestionChosenEventArgs? receivedArgs = null;
+        entry.SuggestionChosen += (_, e) => receivedArgs = e;
+        var item = new { Name = "Test Item" };
+
+        entry.OnSuggestionSelected(item);
+
+        Assert.NotNull(receivedArgs);
+        Assert.Same(item, receivedArgs.SelectedItem);
+    }
+
+    [Fact]
+    public void OnSuggestionSelected_WithNull_SetsSelectedSuggestionToNull()
+    {
+        var entry = CreateEntry();
+        entry.OnSuggestionSelected(new object());
+
+        entry.OnSuggestionSelected(null!);
+
+        Assert.Null(entry.SelectedSuggestion);
+    }
+
+    #endregion
+
+    #region OnCursorPositionChanged
+
+    [Fact]
+    public void OnCursorPositionChanged_UpdatesCursorPositionProperty()
+    {
+        var entry = CreateEntry();
+
+        entry.OnCursorPositionChanged(5);
+
+        Assert.Equal(5, entry.CursorPosition);
+    }
+
+    [Fact]
+    public void OnCursorPositionChanged_FiresCursorPositionChangedEvent()
+    {
+        var entry = CreateEntry();
+        AutoCompleteEntryCursorPositionChangedEventArgs? receivedArgs = null;
+        entry.CursorPositionChanged += (_, e) => receivedArgs = e;
+
+        entry.OnCursorPositionChanged(5);
+
+        Assert.NotNull(receivedArgs);
+        Assert.Equal(5, receivedArgs.CursorPosition);
+    }
+
+    [Fact]
+    public void OnCursorPositionChanged_SamePosition_DoesNotFireEvent()
+    {
+        var entry = CreateEntry();
+        entry.OnCursorPositionChanged(5);
+
+        int eventCount = 0;
+        entry.CursorPositionChanged += (_, _) => eventCount++;
+
+        entry.OnCursorPositionChanged(5);
+
+        Assert.Equal(0, eventCount);
+    }
+
+    [Fact]
+    public void OnCursorPositionChanged_DifferentPosition_FiresEvent()
+    {
+        var entry = CreateEntry();
+        entry.OnCursorPositionChanged(5);
+
+        AutoCompleteEntryCursorPositionChangedEventArgs? receivedArgs = null;
+        entry.CursorPositionChanged += (_, e) => receivedArgs = e;
+
+        entry.OnCursorPositionChanged(10);
+
+        Assert.NotNull(receivedArgs);
+        Assert.Equal(10, receivedArgs.CursorPosition);
+    }
+
+    #endregion
+
+    #region Property Setting
+
+    [Fact]
+    public void IsSuggestionListOpen_CanBeSetToTrue()
+    {
+        var entry = CreateEntry();
+
+        entry.IsSuggestionListOpen = true;
+
+        Assert.True(entry.IsSuggestionListOpen);
+    }
+
+    [Fact]
+    public void UpdateTextOnSelect_CanBeSetToFalse()
+    {
+        var entry = CreateEntry();
+
+        entry.UpdateTextOnSelect = false;
+
+        Assert.False(entry.UpdateTextOnSelect);
+    }
+
+    [Fact]
+    public void ShowBottomBorder_CanBeSetToFalse()
+    {
+        var entry = CreateEntry();
+
+        entry.ShowBottomBorder = false;
+
+        Assert.False(entry.ShowBottomBorder);
+    }
+
+    [Fact]
+    public void ItemsSource_CanBeSet()
+    {
+        var entry = CreateEntry();
+        var items = new List<string> { "one", "two", "three" };
+
+        entry.ItemsSource = items;
+
+        Assert.Same(items, entry.ItemsSource);
+    }
+
+    #endregion
+}

--- a/src/Tests/AutoCompleteEntry.Tests/DensityHelperTests.cs
+++ b/src/Tests/AutoCompleteEntry.Tests/DensityHelperTests.cs
@@ -1,0 +1,104 @@
+using zoft.MauiExtensions.Controls.Platform;
+
+namespace AutoCompleteEntry.Tests;
+
+/// <summary>
+/// Tests for <see cref="DensityHelper"/> — the DIP ↔ pixel conversion logic
+/// used by the Android adapter when measuring suggestion row heights.
+/// </summary>
+public class DensityHelperTests
+{
+    #region WidthPixelsToDipConstraint
+
+    [Theory]
+    [InlineData(1080, 2.75, 392.727)] // typical 1080p Android phone
+    [InlineData(1440, 3.5, 411.429)]  // typical 1440p Android phone
+    [InlineData(720, 2.0, 360.0)]     // hdpi device
+    [InlineData(320, 1.0, 320.0)]     // mdpi (1:1)
+    public void WidthPixelsToDipConstraint_PositiveWidth_ReturnsDipValue(
+        int parentWidthPx, double density, double expectedDip)
+    {
+        var result = DensityHelper.WidthPixelsToDipConstraint(parentWidthPx, density);
+
+        Assert.Equal(expectedDip, result, precision: 3);
+    }
+
+    [Theory]
+    [InlineData(0, 2.75)]
+    [InlineData(-1, 3.0)]
+    [InlineData(-100, 1.0)]
+    public void WidthPixelsToDipConstraint_ZeroOrNegativeWidth_ReturnsPositiveInfinity(
+        int parentWidthPx, double density)
+    {
+        var result = DensityHelper.WidthPixelsToDipConstraint(parentWidthPx, density);
+
+        Assert.Equal(double.PositiveInfinity, result);
+    }
+
+    [Theory]
+    [InlineData(1080, 0.0)]
+    [InlineData(1080, -1.0)]
+    public void WidthPixelsToDipConstraint_ZeroOrNegativeDensity_ReturnsPositiveInfinity(
+        int parentWidthPx, double density)
+    {
+        var result = DensityHelper.WidthPixelsToDipConstraint(parentWidthPx, density);
+
+        Assert.Equal(double.PositiveInfinity, result);
+    }
+
+    #endregion
+
+    #region HeightDipToPixels
+
+    [Theory]
+    [InlineData(44.0, 2.75, 121)]  // 44 * 2.75 = 121.0 → ceil = 121
+    [InlineData(44.0, 3.5, 154)]   // 44 * 3.5  = 154.0 → ceil = 154
+    [InlineData(44.0, 2.0, 88)]    // 44 * 2.0  = 88.0  → ceil = 88
+    [InlineData(44.0, 1.0, 44)]    // 1:1 mdpi
+    public void HeightDipToPixels_StandardDensities_ReturnsCorrectPixels(
+        double heightDip, double density, int expectedPx)
+    {
+        var result = DensityHelper.HeightDipToPixels(heightDip, density);
+
+        Assert.Equal(expectedPx, result);
+    }
+
+    [Fact]
+    public void HeightDipToPixels_FractionalResult_RoundsUp()
+    {
+        // 45.0 * 2.75 = 123.75 → ceil = 124 (never clip content)
+        var result = DensityHelper.HeightDipToPixels(45.0, 2.75);
+
+        Assert.Equal(124, result);
+    }
+
+    [Fact]
+    public void HeightDipToPixels_ZeroHeight_ReturnsZero()
+    {
+        var result = DensityHelper.HeightDipToPixels(0.0, 3.0);
+
+        Assert.Equal(0, result);
+    }
+
+    [Theory]
+    [InlineData(44.0, 0.0)]
+    [InlineData(44.0, -2.0)]
+    public void HeightDipToPixels_ZeroOrNegativeDensity_ReturnsZero(
+        double heightDip, double density)
+    {
+        var result = DensityHelper.HeightDipToPixels(heightDip, density);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void HeightDipToPixels_VerySmallHeight_RoundsUpToAtLeastOne()
+    {
+        // 0.1 * 2.0 = 0.2 → ceil = 1
+        var result = DensityHelper.HeightDipToPixels(0.1, 2.0);
+
+        Assert.Equal(1, result);
+    }
+
+    #endregion
+}

--- a/src/Tests/AutoCompleteEntry.Tests/TemplateIdMapperTests.cs
+++ b/src/Tests/AutoCompleteEntry.Tests/TemplateIdMapperTests.cs
@@ -52,9 +52,14 @@ public class TemplateIdMapperTests
         var template = NewTemplate();
         var idMap = new Dictionary<DataTemplate, int>();
 
-        var result = TemplateIdMapper.GetViewType(template, item, null, idMap);
+        var firstResult = TemplateIdMapper.GetViewType(template, item, null, idMap);
+        var secondResult = TemplateIdMapper.GetViewType(template, item, null, idMap);
+        var thirdResult = TemplateIdMapper.GetViewType(template, item, null, idMap);
 
-        Assert.Equal(0, result);
+        Assert.Equal(0, firstResult);
+        Assert.Equal(0, secondResult);
+        Assert.Equal(0, thirdResult);
+        Assert.Empty(idMap);
     }
 
     #endregion
@@ -173,6 +178,44 @@ public class TemplateIdMapperTests
         TemplateIdMapper.GetViewType(selector, "z", null, idMap);
 
         Assert.Single(idMap);
+    }
+
+    #endregion
+
+    #region MaxViewTypes cap enforcement
+
+    [Fact]
+    public void GetViewType_Selector_ExceedsMaxViewTypes_Throws()
+    {
+        var templates = Enumerable.Range(0, TemplateIdMapper.MaxViewTypes + 1)
+                                  .Select(_ => NewTemplate())
+                                  .ToArray();
+        var selector = new TestSelector(item => templates[(int)item]);
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        // Fill up to the limit — all should succeed
+        for (var i = 0; i < TemplateIdMapper.MaxViewTypes; i++)
+            TemplateIdMapper.GetViewType(selector, i, null, idMap);
+
+        // One more distinct template must throw
+        Assert.Throws<InvalidOperationException>(
+            () => TemplateIdMapper.GetViewType(selector, TemplateIdMapper.MaxViewTypes, null, idMap));
+    }
+
+    [Fact]
+    public void GetViewType_Selector_AtExactLimit_DoesNotThrow()
+    {
+        var templates = Enumerable.Range(0, TemplateIdMapper.MaxViewTypes)
+                                  .Select(_ => NewTemplate())
+                                  .ToArray();
+        var selector = new TestSelector(item => templates[(int)item]);
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        // Exactly MaxViewTypes distinct templates must all succeed
+        for (var i = 0; i < TemplateIdMapper.MaxViewTypes; i++)
+            TemplateIdMapper.GetViewType(selector, i, null, idMap);
+
+        Assert.Equal(TemplateIdMapper.MaxViewTypes, idMap.Count);
     }
 
     #endregion

--- a/src/Tests/AutoCompleteEntry.Tests/TemplateIdMapperTests.cs
+++ b/src/Tests/AutoCompleteEntry.Tests/TemplateIdMapperTests.cs
@@ -1,0 +1,179 @@
+using zoft.MauiExtensions.Controls.Platform;
+
+namespace AutoCompleteEntry.Tests;
+
+/// <summary>
+/// Tests for <see cref="TemplateIdMapper"/> — the template-to-integer-ID mapping logic
+/// used by the Android adapter to maintain separate recycling pools per DataTemplate type.
+/// </summary>
+public class TemplateIdMapperTests
+{
+    // Minimal concrete DataTemplateSelector for testing — DataTemplateSelector.OnSelectTemplate
+    // is protected abstract and cannot be configured via NSubstitute.
+    private sealed class TestSelector : DataTemplateSelector
+    {
+        private readonly Func<object, DataTemplate> _select;
+
+        internal TestSelector(Func<object, DataTemplate> select) => _select = select;
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+            => _select(item);
+    }
+
+    // Returns a new distinct DataTemplate instance each call — used as unique dictionary keys.
+    private static DataTemplate NewTemplate() => new();
+
+    #region Plain DataTemplate (no selector)
+
+    [Fact]
+    public void GetViewType_PlainTemplate_ReturnsZero()
+    {
+        var result = TemplateIdMapper.GetViewType(NewTemplate(), new object(), null, new());
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetViewType_PlainTemplate_DoesNotPopulateMap()
+    {
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        TemplateIdMapper.GetViewType(NewTemplate(), new object(), null, idMap);
+
+        Assert.Empty(idMap);
+    }
+
+    [Theory]
+    [InlineData("a")]
+    [InlineData("b")]
+    [InlineData("c")]
+    public void GetViewType_PlainTemplate_MultipleCalls_AlwaysReturnsZero(string item)
+    {
+        var template = NewTemplate();
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        var result = TemplateIdMapper.GetViewType(template, item, null, idMap);
+
+        Assert.Equal(0, result);
+    }
+
+    #endregion
+
+    #region DataTemplateSelector — ID assignment
+
+    [Fact]
+    public void GetViewType_Selector_FirstEncounteredTemplate_AssignsIdZero()
+    {
+        var templateA = NewTemplate();
+        var selector = new TestSelector(_ => templateA);
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        var result = TemplateIdMapper.GetViewType(selector, "item", null, idMap);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetViewType_Selector_TwoDistinctTemplates_AssignsDifferentIds()
+    {
+        var templateA = NewTemplate();
+        var templateB = NewTemplate();
+        var selector = new TestSelector(item => item is "a" ? templateA : templateB);
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        var idA = TemplateIdMapper.GetViewType(selector, "a", null, idMap);
+        var idB = TemplateIdMapper.GetViewType(selector, "b", null, idMap);
+
+        Assert.NotEqual(idA, idB);
+    }
+
+    [Fact]
+    public void GetViewType_Selector_ThreeDistinctTemplates_AssignsSequentialIds()
+    {
+        var templateA = NewTemplate();
+        var templateB = NewTemplate();
+        var templateC = NewTemplate();
+        var selector = new TestSelector(item => item switch
+        {
+            "a" => templateA,
+            "b" => templateB,
+            _ => templateC
+        });
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        var idA = TemplateIdMapper.GetViewType(selector, "a", null, idMap);
+        var idB = TemplateIdMapper.GetViewType(selector, "b", null, idMap);
+        var idC = TemplateIdMapper.GetViewType(selector, "c", null, idMap);
+
+        Assert.Equal(3, new[] { idA, idB, idC }.Distinct().Count());
+        Assert.Equivalent(new[] { 0, 1, 2 }, new[] { idA, idB, idC });
+    }
+
+    #endregion
+
+    #region DataTemplateSelector — ID stability
+
+    [Fact]
+    public void GetViewType_Selector_SameTemplateInstance_ReturnsSameIdEachTime()
+    {
+        var templateA = NewTemplate();
+        var selector = new TestSelector(_ => templateA);
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        var first = TemplateIdMapper.GetViewType(selector, "x", null, idMap);
+        var second = TemplateIdMapper.GetViewType(selector, "y", null, idMap);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void GetViewType_Selector_IdsDoNotChangeAfterNewTemplateAdded()
+    {
+        var templateA = NewTemplate();
+        var templateB = NewTemplate();
+        var selector = new TestSelector(item => item is "a" ? templateA : templateB);
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        var idA_before = TemplateIdMapper.GetViewType(selector, "a", null, idMap);
+        TemplateIdMapper.GetViewType(selector, "b", null, idMap); // register B
+        var idA_after = TemplateIdMapper.GetViewType(selector, "a", null, idMap);
+
+        Assert.Equal(idA_before, idA_after);
+    }
+
+    #endregion
+
+    #region DataTemplateSelector — map state
+
+    [Fact]
+    public void GetViewType_Selector_PopulatesMapWithResolvedTemplates()
+    {
+        var templateA = NewTemplate();
+        var templateB = NewTemplate();
+        var selector = new TestSelector(item => item is "a" ? templateA : templateB);
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        TemplateIdMapper.GetViewType(selector, "a", null, idMap);
+        TemplateIdMapper.GetViewType(selector, "b", null, idMap);
+
+        Assert.Equal(2, idMap.Count);
+        Assert.Contains(templateA, idMap.Keys);
+        Assert.Contains(templateB, idMap.Keys);
+    }
+
+    [Fact]
+    public void GetViewType_Selector_RepeatedSameTemplate_DoesNotGrowMap()
+    {
+        var templateA = NewTemplate();
+        var selector = new TestSelector(_ => templateA);
+        var idMap = new Dictionary<DataTemplate, int>();
+
+        TemplateIdMapper.GetViewType(selector, "x", null, idMap);
+        TemplateIdMapper.GetViewType(selector, "y", null, idMap);
+        TemplateIdMapper.GetViewType(selector, "z", null, idMap);
+
+        Assert.Single(idMap);
+    }
+
+    #endregion
+}

--- a/src/Tests/AutoCompleteEntry.Tests/Usings.cs
+++ b/src/Tests/AutoCompleteEntry.Tests/Usings.cs
@@ -1,0 +1,4 @@
+﻿global using Xunit;
+global using zoft.MauiExtensions.Controls;
+global using NSubstitute;
+global using System.Windows.Input;

--- a/src/Tests/AutoCompleteEntry.Tests/Usings.cs
+++ b/src/Tests/AutoCompleteEntry.Tests/Usings.cs
@@ -2,3 +2,4 @@
 global using zoft.MauiExtensions.Controls;
 global using NSubstitute;
 global using System.Windows.Input;
+global using Microsoft.Maui.Controls;


### PR DESCRIPTION
- Introduce AutoCompleteEntry.Tests project with xUnit and NSubstitute, covering core control logic and event behavior
- Update .gitignore and solution structure for new test project
- Improve iOS UITableView cell sizing: use automatic dimension, increase min height, and add proper layout constraints
- Clean up code and documentation in main control
- Remove unused usings in iOS implementation