### PR TITLE
feat: automate versioning with MinVer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
@@ -68,6 +70,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,23 +1,17 @@
 name: Publish package
 
 on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       ref:
-        description: Git ref to build
+        description: Git ref to build (branch, tag, or SHA)
         required: false
         default: main
-      release_tag:
-        description: Existing release tag to validate against and optionally attach packages to
-        required: false
-        default: ""
       publish_to_nuget:
         description: Push packages to NuGet.org
-        required: false
-        default: false
-        type: boolean
-      attach_to_release:
-        description: Upload built packages to the existing GitHub release for release_tag
         required: false
         default: false
         type: boolean
@@ -41,29 +35,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Validate manual workflow inputs
-        if: inputs.attach_to_release && inputs.release_tag == ''
-        shell: pwsh
-        run: throw "The 'release_tag' input is required when 'attach_to_release' is enabled."
-
-      - name: Validate tag matches package version
-        if: inputs.release_tag != ''
-        shell: pwsh
-        run: |
-          [xml]$buildProps = Get-Content 'src\Directory.build.props'
-          $packageVersion = $buildProps.SelectSingleNode('//Version').InnerText
-          $tagVersion = '${{ inputs.release_tag }}'.TrimStart('v')
-
-          if ($packageVersion -ne $tagVersion) {
-              throw "Release tag version '$tagVersion' does not match package version '$packageVersion' in src\Directory.build.props."
-          }
 
       - name: Restore MAUI workloads
         shell: pwsh
@@ -83,7 +61,7 @@ jobs:
           if-no-files-found: error
 
       - name: Push package to NuGet.org
-        if: inputs.publish_to_nuget
+        if: github.event_name == 'push' || inputs.publish_to_nuget
         shell: pwsh
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
@@ -108,18 +86,25 @@ jobs:
               Pop-Location
           }
 
-      - name: Attach packages to GitHub release
-        if: inputs.attach_to_release
+      - name: Create or update GitHub release and attach packages
+        if: github.event_name == 'push'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          $tag = '${{ github.ref_name }}'
+
+          $releaseExists = gh release view $tag --json tagName 2>$null
+          if (-not $releaseExists) {
+              gh release create $tag --title "Release $tag" --generate-notes
+          }
+
           Push-Location $env:PACKAGE_OUTPUT
 
           try {
               Get-ChildItem . -Include *.nupkg,*.snupkg -File |
                 ForEach-Object {
-                  gh release upload '${{ inputs.release_tag }}' $_.Name --clobber
+                  gh release upload $tag $_.Name --clobber
                 }
           }
           finally {

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,7 +3,7 @@ name: Publish package
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -79,7 +79,13 @@ jobs:
           }
 
           $packageId = 'zoft.MauiExtensions.Controls.AutoCompleteEntry'
-          $packageVersion = $nupkg.BaseName.Substring($packageId.Length + 1)
+          $expectedPrefix = "$packageId."
+
+          if (-not $nupkg.BaseName.StartsWith($expectedPrefix, [System.StringComparison]::Ordinal)) {
+              throw "Package file '$($nupkg.Name)' does not match the expected package ID '$packageId'. Expected file name to start with '$expectedPrefix'."
+          }
+
+          $packageVersion = $nupkg.BaseName.Substring($expectedPrefix.Length)
 
           if ($packageVersion -ne $tag) {
               throw "Package version '$packageVersion' does not match tag '$tag'. Aborting publish."

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -60,6 +60,33 @@ jobs:
             src/AutoCompleteEntry/bin/Release/*.snupkg
           if-no-files-found: error
 
+      - name: Validate tag and package version
+        if: github.event_name == 'push'
+        shell: pwsh
+        run: |
+          $tag = '${{ github.ref_name }}'
+
+          if ($tag -notmatch '^\d+\.\d+\.\d+$') {
+              throw "Tag '$tag' does not match the required MAJOR.MINOR.PATCH format. Only stable release tags trigger publishing."
+          }
+
+          $nupkg = Get-ChildItem -Path "$env:PACKAGE_OUTPUT" -Filter *.nupkg |
+                     Where-Object { $_.Name -notlike '*.snupkg' } |
+                     Select-Object -First 1
+
+          if (-not $nupkg) {
+              throw "No .nupkg file found in '$env:PACKAGE_OUTPUT'."
+          }
+
+          $packageId = 'zoft.MauiExtensions.Controls.AutoCompleteEntry'
+          $packageVersion = $nupkg.BaseName.Substring($packageId.Length + 1)
+
+          if ($packageVersion -ne $tag) {
+              throw "Package version '$packageVersion' does not match tag '$tag'. Aborting publish."
+          }
+
+          Write-Host "Tag and package version both match: $tag"
+
       - name: Push package to NuGet.org
         if: github.event_name == 'push' || fromJSON(github.event.inputs.publish_to_nuget || 'false')
         shell: pwsh
@@ -102,7 +129,7 @@ jobs:
           Push-Location $env:PACKAGE_OUTPUT
 
           try {
-              Get-ChildItem . -Include *.nupkg,*.snupkg -File |
+              @(Get-ChildItem -Filter *.nupkg; Get-ChildItem -Filter *.snupkg -ErrorAction SilentlyContinue) |
                 ForEach-Object {
                   gh release upload $tag $_.Name --clobber
                 }

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
           fetch-depth: 0
 
       - name: Setup .NET SDK
@@ -61,7 +61,7 @@ jobs:
           if-no-files-found: error
 
       - name: Push package to NuGet.org
-        if: github.event_name == 'push' || inputs.publish_to_nuget
+        if: github.event_name == 'push' || fromJSON(github.event.inputs.publish_to_nuget || 'false')
         shell: pwsh
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ This repository uses **manual GitHub Releases** plus a **manual GitHub Actions p
 1. Update the package version in `src\Directory.build.props`.
 2. Move the pending notes from `CHANGELOG.md` into a new version section.
 3. Merge the release changes to `main`.
-4. Create a **draft GitHub Release** with tag `vX.Y.Z`.
+4. Create a **draft GitHub Release** with tag `X.Y.Z`.
 5. Click **Generate release notes** and refine the result into a short human-friendly summary.
 6. Run the **Publish package** workflow manually from the Actions tab.
 7. Provide:

--- a/src/AutoCompleteEntry/AutoCompleteEntry.csproj
+++ b/src/AutoCompleteEntry/AutoCompleteEntry.csproj
@@ -23,7 +23,7 @@
 
 	<!-- Referenced Nuget Packages -->
 	<ItemGroup>
-		<PackageReference Include="MinVer" Version="4.*" PrivateAssets="all" />
+		<PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="all" />
 		<PackageReference Include="zoft.MauiExtensions.Core" Version="5.2.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	</ItemGroup>

--- a/src/AutoCompleteEntry/AutoCompleteEntry.csproj
+++ b/src/AutoCompleteEntry/AutoCompleteEntry.csproj
@@ -23,6 +23,7 @@
 
 	<!-- Referenced Nuget Packages -->
 	<ItemGroup>
+		<PackageReference Include="MinVer" Version="4.*" PrivateAssets="all" />
 		<PackageReference Include="zoft.MauiExtensions.Core" Version="5.2.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	</ItemGroup>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -11,7 +11,6 @@
     <PackageProjectUrl>https://github.com/zleao/zoft.MauiExtensions.AutoCompleteEntry</PackageProjectUrl>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>4.0.5</Version>
     <Description>.Net MAUI Entry control that provides a list of suggestions as the user types.</Description>
     <PackageTags>net9 maui zoft AutoCompleteEntry AutoCompleteBox AutoCompleteView AutoComplete</PackageTags>
     <PackageReleaseNotes>


### PR DESCRIPTION
## Summary

Replaces the manually maintained <Version> in Directory.build.props with [MinVer](https://github.com/adamralph/minver), a zero-config build-time versioning tool that derives the package version from the nearest Git tag.

## What changed

| File | Change |
|------|--------|
| src/AutoCompleteEntry/AutoCompleteEntry.csproj | Added MinVer 4.* (build-only, PrivateAssets=all) |
| src/Directory.build.props | Removed hardcoded <Version>4.0.5</Version> |
| .github/workflows/ci.yml | Added etch-depth: 0 to both checkout steps so MinVer can find tags during PR builds |
| .github/workflows/publish-package.yml | New tag-push trigger + auto GitHub release creation + removed manual version validation step |

## How versioning now works

- **On a tagged commit** (e.g. 4.0.6): MinVer sets version to 4.0.6
- **Between tags** (e.g. 3 commits after 4.0.5): MinVer sets version to 4.0.6-alpha.0.3 (pre-release, great for CI artifacts)
- No  prefix — matches the existing tag convention (4.0.5, 4.0.4, …)

## New release workflow

```bash
git tag 4.0.6
git push origin 4.0.6
```

That's it. The publish workflow fires automatically, builds the package, pushes to NuGet, and creates (or updates) the GitHub release with the .nupkg/.snupkg assets attached.

The workflow_dispatch trigger is kept as a manual escape hatch (e.g. for re-runs or dry builds without a tag).

## Verified locally

Build produces zoft.MauiExtensions.Controls.AutoCompleteEntry.4.0.6-alpha.0.3.nupkg on this pre-release branch — confirming MinVer correctly reads the 4.0.5 tag and auto-increments.