### PR TITLE
feat: inject release notes from CHANGELOG.md into NuGet package

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,10 @@ This repository is a **.NET MAUI control library** for `zoft.MauiExtensions.Cont
 - Run the sample app on Windows:
   - `dotnet run --project sample\AutoCompleteEntry.Sample\AutoCompleteEntry.Sample.csproj -f net9.0-windows10.0.19041.0`
 
-There is **no dedicated automated test project** in the repository right now, so there is no single-test command to use. The sample app is the main integration surface for behavior changes.
+- Run the unit tests:
+  - `dotnet test src\Tests\AutoCompleteEntry.Tests\AutoCompleteEntry.Tests.csproj`
+
+The sample app remains the main integration surface for platform behavior changes.
 
 ## Architecture
 - `AutoCompleteEntry.cs` is the shared public surface: bindable properties, events, and the control-side state transitions.
@@ -29,6 +32,12 @@ There is **no dedicated automated test project** in the repository right now, so
   - Windows uses `AutoSuggestBox`
   - iOS and MacCatalyst use a custom `IOSAutoCompleteEntry` view with a text field plus suggestion table
 - The control does **not** own filtering logic. Consumers update `ItemsSource` in response to `TextChangedCommand` or the `TextChanged` event.
+
+## Changelog
+- Every user-visible change (new feature, bug fix, behavior change, deprecation) must be recorded in `CHANGELOG.md` before the work is committed.
+- Add entries under the `## [Unreleased]` section using [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) subsections: `Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security`.
+- Pure internal changes (refactoring with no observable effect, test additions, CI/tooling updates) do not require a changelog entry.
+- `CHANGELOG.md` is the source of truth for NuGet `PackageReleaseNotes`: the publish workflow extracts the matching version section automatically on each tag push, so an accurate changelog is essential.
 
 ## Repo-specific conventions
 - Treat the public API as stable. This is a published NuGet package, so prefer additive or opt-in changes over renaming or changing existing behavior.

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -44,22 +44,30 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Extract release notes from CHANGELOG.md
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_nuget == 'true')
         shell: pwsh
         run: |
           $changelog = Get-Content 'CHANGELOG.md' -Raw
-          $version = '${{ github.ref_name }}'.TrimStart('v')
+          $tag = git describe --tags --exact-match 2>$null
 
-          # Match the section for this version: from "## [version]" line to the next "## [" or end of file
-          $escaped_version = [regex]::Escape($version)
-          $pattern = "(?m)^## \[$escaped_version\][^\n]*\r?\n(.*?)(?=\r?\n## \[|\z)"
-          $notes = [regex]::Match($changelog, $pattern, [System.Text.RegularExpressions.RegexOptions]::Singleline).Groups[1].Value.Trim()
-
-          if ([string]::IsNullOrWhiteSpace($notes)) {
-              Write-Warning "No release notes found in CHANGELOG.md for version '$version'. Package will have no release notes."
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($tag)) {
+              Write-Warning "The checked-out ref is not an exact tag. Package will have no release notes."
+              $version = ""
               $notes = ""
           } else {
-              Write-Host "Release notes extracted for version '$version'."
+              $version = $tag.Trim().TrimStart('v')
+
+              # Match the section for this version: from "## [version]" line to the next "## [" or end of file
+              $escaped_version = [regex]::Escape($version)
+              $pattern = "(?m)^## \[$escaped_version\][^\n]*\r?\n(.*?)(?=\r?\n## \[|\z)"
+              $notes = [regex]::Match($changelog, $pattern, [System.Text.RegularExpressions.RegexOptions]::Singleline).Groups[1].Value.Trim()
+
+              if ([string]::IsNullOrWhiteSpace($notes)) {
+                  Write-Warning "No release notes found in CHANGELOG.md for version '$version'. Package will have no release notes."
+                  $notes = ""
+              } else {
+                  Write-Host "Release notes extracted for version '$version'."
+              }
           }
 
           # XML-escape the content and write ReleaseNotes.g.props so MSBuild picks it up automatically

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -43,6 +43,35 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Extract release notes from CHANGELOG.md
+        if: github.event_name == 'push'
+        shell: pwsh
+        run: |
+          $changelog = Get-Content 'CHANGELOG.md' -Raw
+          $version = '${{ github.ref_name }}'.TrimStart('v')
+
+          # Match the section for this version: from "## [version]" line to the next "## [" or end of file
+          $escaped_version = [regex]::Escape($version)
+          $pattern = "(?m)^## \[$escaped_version\][^\n]*\r?\n(.*?)(?=\r?\n## \[|\z)"
+          $notes = [regex]::Match($changelog, $pattern, [System.Text.RegularExpressions.RegexOptions]::Singleline).Groups[1].Value.Trim()
+
+          if ([string]::IsNullOrWhiteSpace($notes)) {
+              Write-Warning "No release notes found in CHANGELOG.md for version '$version'. Package will have no release notes."
+              $notes = ""
+          } else {
+              Write-Host "Release notes extracted for version '$version'."
+          }
+
+          # XML-escape the content and write ReleaseNotes.g.props so MSBuild picks it up automatically
+          $xmlEscaped = [System.Security.SecurityElement]::Escape($notes)
+          @"
+          <Project>
+            <PropertyGroup>
+              <PackageReleaseNotes>$xmlEscaped</PackageReleaseNotes>
+            </PropertyGroup>
+          </Project>
+          "@ | Set-Content 'src/ReleaseNotes.g.props' -Encoding utf8
+
       - name: Restore MAUI workloads
         shell: pwsh
         run: dotnet workload restore $env:PROJECT_FILE

--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,6 @@ src/.DS_Store
 .DS_Store
 
 .vshistory/
+
+# CI-generated release notes props file (created by publish-package.yml, never committed)
+src/ReleaseNotes.g.props

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -13,10 +13,6 @@
     <NeutralLanguage>en</NeutralLanguage>
     <Description>.Net MAUI Entry control that provides a list of suggestions as the user types.</Description>
     <PackageTags>net9 maui zoft AutoCompleteEntry AutoCompleteBox AutoCompleteView AutoComplete</PackageTags>
-    <PackageReleaseNotes>
-		[MACCATALYST] Improve support to MAcCatalyst, including ItemTemplate, Width/Height handling, and more.
-		[BUGFIX] Fire base TextChanged event
-	</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <LangVersion>latest</LangVersion>
@@ -37,6 +33,9 @@
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+
+  <!-- Release notes are injected at publish time from CHANGELOG.md via ReleaseNotes.g.props (CI-generated, git-ignored) -->
+  <Import Project="$(MSBuildThisFileDirectory)ReleaseNotes.g.props" Condition="Exists('$(MSBuildThisFileDirectory)ReleaseNotes.g.props')" />
 
   <!-- Nuget package included files -->
   <ItemGroup>


### PR DESCRIPTION
## Problem

`PackageReleaseNotes` in `src/Directory.build.props` was a hardcoded string that quickly became stale — no link to `CHANGELOG.md`.

## Solution

`CHANGELOG.md` is now the single source of truth for release notes.

### How it works

1. **`Directory.build.props`** — removes the hardcoded `<PackageReleaseNotes>` and instead conditionally imports a CI-generated `ReleaseNotes.g.props` (git-ignored).

2. **Publish workflow** — on every tag push, a step parses `CHANGELOG.md`, extracts the section matching the pushed tag, XML-escapes it, and writes `src/ReleaseNotes.g.props` before the build step runs.
   - Uses `github.ref_name` (the pushed tag) to locate the correct section
   - Warns (but does not fail) if no matching section is found

3. **Local builds** — `ReleaseNotes.g.props` won't exist locally, so the import is silently skipped. Pre-release packages will have no release notes, which is intentional.

## Required CHANGELOG.md format

Each version section must start with `## [X.Y.Z]` (Keep a Changelog format):

```markdown
## [4.0.6]

### Added
- ...

### Fixed
- ...
```
