### PR TITLE
chore: centralize SDK version in global.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'src/**/*.props'
       - 'src/**/*.targets'
       - 'src/**/*.sln'
+      - 'global.json'
   workflow_dispatch:
 
 permissions:
@@ -21,7 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: 9.0.300
   BUILD_CONFIGURATION: Release
   PROJECT_FILE: src\AutoCompleteEntry\AutoCompleteEntry.csproj
   TEST_PROJECT_FILE: src\Tests\AutoCompleteEntry.Tests\AutoCompleteEntry.Tests.csproj
@@ -40,7 +40,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Restore MAUI workloads
         shell: pwsh
@@ -76,7 +76,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Restore MAUI workloads
         shell: pwsh

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,7 +21,6 @@ permissions:
   contents: write
 
 env:
-  DOTNET_VERSION: 9.0.300
   BUILD_CONFIGURATION: Release
   PROJECT_FILE: src\AutoCompleteEntry\AutoCompleteEntry.csproj
   PACKAGE_OUTPUT: src\AutoCompleteEntry\bin\Release
@@ -42,7 +41,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Extract release notes from CHANGELOG.md
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_nuget == 'true')

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.313",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
## Summary

Introduces `global.json` as the single source of truth for the .NET SDK version, removing the duplicated `DOTNET_VERSION` env var from both workflow files.

## Problem

The SDK version was hardcoded independently in `ci.yml` and `publish-package.yml`. Keeping them in sync is manual and error-prone.

## Changes

**`global.json`** (new file)
- Pins to `9.0.313` -- the latest stable 9.0 patch (security fixes vs `9.0.300`).
- `rollForward: latestPatch` allows acceptance of future patch releases in the `9.0.3xx` band for local dev; CI always installs the exact version via `setup-dotnet`'s `global-json-file` input.

**`ci.yml`**
- Removed `DOTNET_VERSION: 9.0.300` env var.
- Each `Setup .NET SDK` step now uses `global-json-file: global.json`.
- Added `global.json` to the `paths` filter so a version bump re-runs CI automatically.

**`publish-package.yml`**
- Removed `DOTNET_VERSION: 9.0.300` env var.
- `Setup .NET SDK` step now uses `global-json-file: global.json`.

## To upgrade the SDK in future

Edit the single `version` field in `global.json`. CI picks it up automatically on the next push.